### PR TITLE
📝 Document deprecating a version of C-PAC

### DIFF
--- a/docs/_sources/conf.py
+++ b/docs/_sources/conf.py
@@ -573,13 +573,23 @@ texinfo_documents = [
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 # texinfo_show_urls = 'footnote'
 
+rst_prolog = """
+
+.. |version as code| replace:: ``{version}``
+
+""".format(
+    version=f'v{version}' if not version.endswith('dev') else 'nightly'
+)
+
 rst_epilog = """
+
 
 .. |Versions| replace:: {versions}
 
 """.format(
     versions=', '.join(gh_tags[:5])
 ) if len(gh_tags) >= 5 else ""
+
 
 def setup(app):
     from CPAC.utils.monitoring import custom_logging

--- a/docs/_sources/developer/deprecating.rst
+++ b/docs/_sources/developer/deprecating.rst
@@ -22,7 +22,7 @@ To semiautomatically deprecate a published version of C-PAC, follow these steps:
          .. code:: Python
 
             shutil.copyfile('/CRITICAL_ALERT.rst',
-               os.path.join(log_dir, 'CRITICAL_ALERT.rst'))
+                            os.path.join(log_dir, 'CRITICAL_ALERT.rst'))
 
          to |cpac_pipeline.py|_ after
 
@@ -84,8 +84,9 @@ To semiautomatically deprecate a published version of C-PAC, follow these steps:
          .. code:: Python
 
             with open('/CRITICAL_ALERT.rst', 'r') as critical_alert_file:
-               critical_alert = critical_alert_file.read()
-
+               critical_alert = ''.join([line for line in
+                                         critical_alert_file.readlines() if
+                                         not line.startswith('.. ')])
             print(critical_alert)
 
    #. From the ``deprecate`` subdirectory, run

--- a/docs/_sources/developer/deprecating.rst
+++ b/docs/_sources/developer/deprecating.rst
@@ -15,6 +15,7 @@ To semiautomatically deprecate a published version of C-PAC, follow these steps:
 
    #. Replace the critical alert in |CRITICAL_ALERT.rst|_ with the ``CRITICAL_ALERT`` from step one, above.
    #. Update |cpac_pipeline.py|_ and |run.py|_:
+
       #. Overwrite the current versions in the |CPAC-Development/deprecate|_ with the versions from the source code of the version of C-PAC to deprecate.
       #. Add
 
@@ -143,25 +144,25 @@ To semiautomatically deprecate a published version of C-PAC, follow these steps:
 
 .. _cpac_pipeline.py: https://github.com/FCP-INDI/CPAC-Development/blob/DEPRECATE/deprecate/cpac_pipeline.py
 
-.. |cpac_pipeline.py example 1| replace:: ``cpac_pipeline.py#L264-L265@bc6081c``
+.. |cpac_pipeline.py example 1| replace:: ``cpac_pipeline.py#L264-L265@6cd6c67``
 
-.. _cpac_pipeline.py example 1: https://github.com/FCP-INDI/CPAC-Development/blob/bc6081c/deprecate/cpac_pipeline.py#L264-L265
+.. _cpac_pipeline.py example 1: https://github.com/FCP-INDI/CPAC-Development/blob/6cd6c67/deprecate/cpac_pipeline.py#L264-L265
 
-.. |cpac_pipeline.py example 2| replace:: ``cpac_pipeline.py#L370@bc6081c``
+.. |cpac_pipeline.py example 2| replace:: ``cpac_pipeline.py#L370@6cd6c67``
 
-.. _cpac_pipeline.py example 2: https://github.com/FCP-INDI/CPAC-Development/blob/bc6081c/deprecate/cpac_pipeline.py#L370
+.. _cpac_pipeline.py example 2: https://github.com/FCP-INDI/CPAC-Development/blob/6cd6c67/deprecate/cpac_pipeline.py#L370
 
-.. |cpac_pipeline.py example 3| replace:: ``cpac_pipeline.py#L705@bc6081c``
+.. |cpac_pipeline.py example 3| replace:: ``cpac_pipeline.py#L706@6cd6c67``
 
-.. _cpac_pipeline.py example 3: https://github.com/FCP-INDI/CPAC-Development/blob/bc6081c/deprecate/cpac_pipeline.py#L705
+.. _cpac_pipeline.py example 3: https://github.com/FCP-INDI/CPAC-Development/blob/6cd6c67/deprecate/cpac_pipeline.py#L706
 
-.. |cpac_pipeline.py example 4| replace:: ``cpac_pipeline.py#L373-L375@bc6081c``
+.. |cpac_pipeline.py example 4| replace:: ``cpac_pipeline.py#L373-L376@6cd6c67``
 
-.. _cpac_pipeline.py example 4: https://github.com/FCP-INDI/CPAC-Development/blob/bc6081c/deprecate/cpac_pipeline.py#L373-L375
+.. _cpac_pipeline.py example 4: https://github.com/FCP-INDI/CPAC-Development/blob/6cd6c67/deprecate/cpac_pipeline.py#L373-L376
 
-.. |cpac_pipeline.py example 5| replace:: ``cpac_pipeline.py#L722@bc6081c``
+.. |cpac_pipeline.py example 5| replace:: ``cpac_pipeline.py#L723@6cd6c67``
 
-.. _cpac_pipeline.py example 5: https://github.com/FCP-INDI/CPAC-Development/blob/bc6081c/deprecate/cpac_pipeline.py#L722
+.. _cpac_pipeline.py example 5: https://github.com/FCP-INDI/CPAC-Development/blob/6cd6c67/deprecate/cpac_pipeline.py#L723
 
 .. |Docker Hub tags| replace:: fcpindi/c-pac Tags | Docker Hub
 
@@ -171,9 +172,9 @@ To semiautomatically deprecate a published version of C-PAC, follow these steps:
 
 .. _run.py: https://github.com/FCP-INDI/CPAC-Development/blob/DEPRECATE/deprecate/run.py
 
-.. |run.py example 1| replace:: ``run.py#L216-L219@bc6081c``
+.. |run.py example 1| replace:: ``run.py#L216-L220@6cd6c67``
 
-.. _run.py example 1: https://github.com/FCP-INDI/CPAC-Development/blob/bc6081c/deprecate/run.py#L216-L219
+.. _run.py example 1: https://github.com/FCP-INDI/CPAC-Development/blob/6cd6c67/deprecate/run.py#L216-L220
 
 .. |semver| raw:: HTML
 

--- a/docs/_sources/developer/deprecating.rst
+++ b/docs/_sources/developer/deprecating.rst
@@ -14,6 +14,79 @@ To semiautomatically deprecate a published version of C-PAC, follow these steps:
       In a local clone or copy of |CPAC-Development|_:
 
    #. Replace the critical alert in |CRITICAL_ALERT.rst|_ with the ``CRITICAL_ALERT`` from step one, above.
+   #. Update |cpac_pipeline.py|_ and |run.py|_:
+      #. Overwrite the current versions in the |CPAC-Development/deprecate|_ with the versions from the source code of the version of C-PAC to deprecate.
+      #. Add
+
+         .. code:: Python
+
+            shutil.copyfile('/CRITICAL_ALERT.rst',
+               os.path.join(log_dir, 'CRITICAL_ALERT.rst'))
+
+         to |cpac_pipeline.py|_ after
+
+         .. code:: Python
+
+            if not os.path.exists(log_dir):
+               os.makedirs(os.path.join(log_dir))
+
+         (e.g., |cpac_pipeline.py example 1|_) and make sure ``shutil`` is imported before calling that library.
+
+      #. Also in |cpac_pipeline.py|_, update the variable ``execution_info`` to include ``{critical_alert}`` at the end, like |cpac_pipeline.py example 2|_:
+
+         .. code:: Python
+
+            execution_info = """
+
+               End of subject workflow {workflow}
+
+               CPAC run complete:
+
+                  Pipeline configuration: {pipeline}
+                  Subject workflow: {workflow}
+                  Elapsed run time (minutes): {elapsed}
+                  Timing information saved in {log_dir}/cpac_individual_timing_{pipeline}.csv
+                  System time of start:      {run_start}
+                  System time of completion: {run_finish}
+
+            {critical_alert}
+            """
+
+         .. note::
+
+            There are probably at least two definitions of ``execution_info`` that need ``{critical_alert}`` appended to them (e.g., |cpac_pipeline.py example 3|_).
+
+      #. Also in |cpac_pipeline.py|_, define ``critical_alert`` based on the |CRITICAL_ALERT.rst|_ file you already updated (e.g., |cpac_pipeline.py example 4|_):
+
+         .. code:: Python
+
+            with open('/CRITICAL_ALERT.rst', 'r') as critical_alert_file:
+               critical_alert = '\n'.join([
+                     f'    {line.rstrip()}' for line in critical_alert_file.readlines()])
+
+      #. Also in |cpac_pipeline.py|_, update any calls to ``execution_info.format()`` to populate the string variable ``{critical_alert}`` with the ``critical_alert`` you defined above (e.g., |cpac_pipeline.py example 5|_):
+
+         .. code:: Python
+
+            logger.info(execution_info.format(
+               workflow=workflow.name,
+               pipeline=c.pipeline_setup['pipeline_name'],
+               log_dir=c.pipeline_setup['log_directory']['path'],
+               elapsed=(time.time() - pipeline_start_time) / 60,
+               run_start=pipeline_start_datetime,
+               run_finish=strftime("%Y-%m-%d %H:%M:%S"),
+               critical_alert=critical_alert
+            ))
+
+      #. In |run.py|_, print the contents of |CRITICAL_ALERT.rst|_, e.g. |run.py example 1|_:
+
+         .. code:: Python
+
+            with open('/CRITICAL_ALERT.rst', 'r') as critical_alert_file:
+               critical_alert = critical_alert_file.read()
+
+            print(critical_alert)
+
    #. From the ``deprecate`` subdirectory, run
    
       .. code:: BASH
@@ -66,9 +139,41 @@ To semiautomatically deprecate a published version of C-PAC, follow these steps:
 
 .. _CPAC-Development/deprecate: https://github.com/FCP-INDI/CPAC-Development/tree/028e7929188df99241e8eea78d20d0fd27dbe509/deprecate
 
+.. |cpac_pipeline.py| replace:: ``cpac_pipeline.py``
+
+.. _cpac_pipeline.py: https://github.com/FCP-INDI/CPAC-Development/blob/DEPRECATE/deprecate/cpac_pipeline.py
+
+.. |cpac_pipeline.py example 1| replace:: ``cpac_pipeline.py#L264-L265@bc6081c``
+
+.. _cpac_pipeline.py example 1: https://github.com/FCP-INDI/CPAC-Development/blob/bc6081c/deprecate/cpac_pipeline.py#L264-L265
+
+.. |cpac_pipeline.py example 2| replace:: ``cpac_pipeline.py#L370@bc6081c``
+
+.. _cpac_pipeline.py example 2: https://github.com/FCP-INDI/CPAC-Development/blob/bc6081c/deprecate/cpac_pipeline.py#L370
+
+.. |cpac_pipeline.py example 3| replace:: ``cpac_pipeline.py#L705@bc6081c``
+
+.. _cpac_pipeline.py example 3: https://github.com/FCP-INDI/CPAC-Development/blob/bc6081c/deprecate/cpac_pipeline.py#L705
+
+.. |cpac_pipeline.py example 4| replace:: ``cpac_pipeline.py#L373-L375@bc6081c``
+
+.. _cpac_pipeline.py example 4: https://github.com/FCP-INDI/CPAC-Development/blob/bc6081c/deprecate/cpac_pipeline.py#L373-L375
+
+.. |cpac_pipeline.py example 5| replace:: ``cpac_pipeline.py#L722@bc6081c``
+
+.. _cpac_pipeline.py example 5: https://github.com/FCP-INDI/CPAC-Development/blob/bc6081c/deprecate/cpac_pipeline.py#L722
+
 .. |Docker Hub tags| replace:: fcpindi/c-pac Tags | Docker Hub
 
 .. _Docker Hub tags: https://hub.docker.com/repository/docker/fcpindi/c-pac/tags
+
+.. |run.py| replace:: ``run.py``
+
+.. _run.py: https://github.com/FCP-INDI/CPAC-Development/blob/DEPRECATE/deprecate/run.py
+
+.. |run.py example 1| replace:: ``run.py#L216-L219@bc6081c``
+
+.. _run.py example 1: https://github.com/FCP-INDI/CPAC-Development/blob/bc6081c/deprecate/run.py#L216-L219
 
 .. |semver| raw:: HTML
 

--- a/docs/_sources/developer/deprecating.rst
+++ b/docs/_sources/developer/deprecating.rst
@@ -1,0 +1,75 @@
+Deprecating a version of C-PAC
+==============================
+
+In the rare occasion that a version of C-PAC needs to be deprecated, we add |CRITICAL_ALERT.rst| as a runtime warning and rename the deprecated image tag to ``${DEPRECATED_TAG}-DEPRECATED`` and replace the original tag for the deprecated image with an image that only displays |CRITICAL_ALERT.rst|_. For example, ``fcpindi/c-pac:release-v1.8.1-DEPRECATED`` is the tag that would be needed to run v1.8.1 after v1.8.1 was deprecated.
+
+To semiautomatically deprecate a published version of C-PAC, follow these steps:
+
+#. Write a ``CRITICAL ALERT`` (e.g., |CRITICAL ALERT 1.8.4|_) describing the need for the deprecation, the affected versions, and any recommendations. 
+#. Include that ``CRITICAL ALERT`` in the GitHub release notes for new version (e.g., |1.8.4 release notes|_).
+#. Use |CPAC-Development/deprecate|_ to deprecate the affected version images on Docker Hub. This process requires adequate permissions in the `fcp-indi organization on Docker Hub <https://hub.docker.com/orgs/fcpindi>`_ to ``docker push``.
+
+   #. If you aren't already logged into Docker Hub, ``docker login``.
+
+      In a local clone or copy of |CPAC-Development|_:
+
+   #. Replace the critical alert in |CRITICAL_ALERT.rst|_ with the ``CRITICAL_ALERT`` from step one, above.
+   #. From the ``deprecate`` subdirectory, run
+   
+      .. code:: BASH
+
+         ./build_and_deprecate ${DEPRECATED_TAG} ${RECOMMENDED_MINIMUM_VERSION}
+
+      for each tag (as ``${DEPRECATED_TAG}``) that needs to be deprecated. This script will build the replacement images and push them to Docker Hub, overwriting the original image. See |Docker Hub tags|_ for all C-PAC tags currently published on Docker Hub. ``${RECOMMENDED_MINIMUM_VERSION}`` is the |semver| without any leading ``v``. For example
+
+      .. code:: BASH
+
+         for each TAG in "" -lite -ABCD-HCP -fMRIPrep-LTS
+         do
+           ./build_and_deprecate release-v1.8.1$TAG 1.8.4
+         done
+
+      to deprecate all variants of C-PAC v1.8.1 with recommended mimumum version v1.8.4.
+
+      If the version to be deprecated is already deprecated but the critical alert needs to be updated, that can be done with the same syntax with ``./rebuild_and_deprecate`` (e.g., 
+      
+      .. code:: BASH
+
+         ./rebuild_and_deprecate release-v1.8.1-lite 1.8.4
+
+      to update the critical alert for ``release-v1.8.1-lite`` and ``release-v1.8.1-DEPRECATED``).
+
+#. Add the critical alert to the release notes of each newly deprecated version, or update the critical alert if one already exists for that version (e.g., |1.8.1 release notes|_).
+#. Trigger a rebuild of this documentation for the new version of C-PAC.
+
+.. |1.8.1 release notes| replace:: ``C-PAC/releases/v.1.8.1`` "C-PAC Version 1.8.1 Beta"
+
+.. _1.8.1 release notes: https://github.com/FCP-INDI/C-PAC/releases/tag/v1.8.1
+
+.. |1.8.4 release notes| replace:: ``C-PAC/releases/v.1.8.4`` "C-PAC Version 1.8.4 Beta"
+
+.. _1.8.4 release notes: https://github.com/FCP-INDI/C-PAC/releases/tag/v1.8.4
+
+.. |CRITICAL ALERT 1.8.4| replace:: "Critical Alert for fMRIPrep-Options in C-PAC v1.8.1 - v1.8.3"
+
+.. _CRITICAL ALERT 1.8.4: https://github.com/FCP-INDI/CPAC-Development/blob/028e792/deprecate/CRITICAL_ALERT.rst#critical-alert-for-fmriprep-options-in-c-pac-v181---v183
+
+.. |CRITICAL_ALERT.rst| replace:: ``CRITICAL_ALERT.rst``
+
+.. _CRITICAL_ALERT.rst: https://github.com/FCP-INDI/CPAC-Development/blob/main/deprecate/CRITICAL_ALERT.rst
+
+.. |CPAC-Development| replace:: ``CPAC-Development``
+
+.. _CPAC-Development: https://github.com/FCP-INDI/CPAC-Development
+
+.. |CPAC-Development/deprecate| replace:: ``CPAC-Development/deprecate``
+
+.. _CPAC-Development/deprecate: https://github.com/FCP-INDI/CPAC-Development/tree/028e7929188df99241e8eea78d20d0fd27dbe509/deprecate
+
+.. |Docker Hub tags| replace:: fcpindi/c-pac Tags | Docker Hub
+
+.. _Docker Hub tags: https://hub.docker.com/repository/docker/fcpindi/c-pac/tags
+
+.. |semver| raw:: HTML
+
+   <span title="semantic version">semver</span>

--- a/docs/_sources/developer/index.rst
+++ b/docs/_sources/developer/index.rst
@@ -25,6 +25,7 @@ Contents:
    xcpqc
    testing
    continuous_integration
+   deprecating
 
 Indices and tables
 ^^^^^^^^^^^^^^^^^^

--- a/docs/_sources/user/cpac.rst
+++ b/docs/_sources/user/cpac.rst
@@ -24,7 +24,7 @@ or
 
     cpac upgrade
 
-When downloading/upgrading, the ``--platform``, ``--image``, and ``--tag`` let you specify platform (Docker or Singularity), image (Docker image name or URL to image in repository), and tag (version tag, currently only for Docker repositories), respectively.
+When downloading/upgrading, the ``--platform``, ``--image``, and ``--tag`` let you specify platform (Docker or Singularity), image (Docker image name or URL to image in repository), and tag (:doc:`version tag </user/versions>`), respectively.
 
 For example, a development Docker image can be downloaded with
 
@@ -69,6 +69,8 @@ Usage
 * Pull ``fcpindi/c-pac:latest`` from Docker Hub and convert to a Singularity image.
 
 You can also specify a container image with an ``--image`` argument, passing an image name (e.g., ``fcpindi/c-pac``) for a Docker image or a filepath (e.g. ``~/singularity_images/C-PAC.sif``) for a Singularity image. You can also specify a ``--tag`` (e.g., ``latest`` or ``nightly``).
+
+   .. seealso:: :doc:`/user/versions`
 
 You can also provide a link to an AWS S3 bucket containing a BIDS directory as the data source:
 
@@ -115,7 +117,3 @@ Note that any of the optional arguments above will over-ride any pipeline settin
 * The ``participant_label`` and ``participant_ndx`` arguments allow the user to specify which of the many datasets should be processed, which is useful when parallelizing the run of multiple participants.
 
 * If you want to pass runtime options to your container plaform (Docker or Singularity), you can pass them with ``-o`` or ``--container_options``.
-
-.. rubric:: Footnotes
-
-.. [*] The version restrictions for Singularity are specific to cpac the convenience wrapper. C-PAC itself should :doc:`run on Singularity <singularity>` 2 or 3.

--- a/docs/_sources/user/docker.rst
+++ b/docs/_sources/user/docker.rst
@@ -15,6 +15,8 @@ To start, first pull the image from Docker Hub:
 
 Once this is complete, you can use the ``fcpindi/c-pac:latest`` image tag to invoke runs. The full C-PAC Docker image usage options are shown here, with some specific use cases.
 
+   .. seealso:: :doc:`/user/versions`
+
 As a quick example, in order to run the C-PAC Docker container in participant mode, for one participant, using a BIDS dataset stored on your machine or server, and using the Docker image's default pipeline configuration (broken into multiple lines for visual clarity):
 
 .. code-block:: console

--- a/docs/_sources/user/index.rst
+++ b/docs/_sources/user/index.rst
@@ -113,3 +113,8 @@ User Guide Index
    10. Troubleshoot <help>
    11. Release Notes <rnotes>
    12. Appendix <appendix>
+
+.. toctree::
+   :hidden:
+
+   versions

--- a/docs/_sources/user/versions.rst
+++ b/docs/_sources/user/versions.rst
@@ -1,0 +1,29 @@
+C-PAC versions
+==============
+
+See :doc:`Release Notes </user/rnotes>` for information about specific versions of C-PAC. The Docker Hub tags are like ``fcpindi/c-pac:release-${VERSION}${VARIANT}`` where ``${VERSION}`` is either a specific semantic version prefixed with a ``v`` or ``latest`` or ``nightly``, like |example version|
+
+Variants
+^^^^^^^^
+
+Primary image
+-------------
+
+Non-variant, primary image (no ``${VARIANT}`` or an empty string, e.g. |example version|)
+
+Lite variant
+------------
+
+``-lite``, primary image without FreeSurfer for a smaller image for runs that don't need FreeSurfer (e.g., |example version|\ ``-lite``)
+
+ABCD-HCP variant
+----------------
+
+``-ABCD-HCP``, image with software dependencies version-matched to `ABCD-HCP BIDS fMRI Pipeline <https://github.com/DCAN-Labs/abcd-hcp-pipeline/blob/e480a8f99534f1b05f37bf44c64827384b69b383/Dockerfile>`_ (e.g., |example version|\ ``-ABCD-HCP``)
+
+fMRIPrep-LTS variant
+--------------------
+
+``-fMRIPrep-LTS``, image with software dependencies version-matched to `fMRIPrep LTS <https://reproducibility.stanford.edu/fmriprep-lts#long-term-support-lts>`_ (e.g., |example version|\ ``-fMRIPrep-LTS``)
+
+.. |example version| replace:: ``release-``\ |version as code|


### PR DESCRIPTION
## Documents
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Documents #[issue number]" to "Documents #1". -->
Documents https://github.com/FCP-INDI/CPAC-Development/pull/6 by @shnizzedy

## Description
<!-- Concisely describe what the pull request does. -->
* Adds developer documentation for how to use [`deprecate` scripts](https://github.com/FCP-INDI/CPAC-Development/tree/1f9a268a9aad502432c0a689a1a07ff33d7530ca/deprecate) in [FCP-INDI/CPAC-Development](https://github.com/FCP-INDI/CPAC-Development) to deprecate a published C-PAC image
* Adds information about C-PAC versions to user documentation

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
### Developer docs

#### fcp-indi.github.io/docs/nightly/developer
![fcp-indi.github.io/docs/nightly/developer](https://user-images.githubusercontent.com/5974438/178534279-b7500df0-9392-4869-b8ac-91d6c9ea4a97.png)

#### fcp-indi.github.io/docs/nightly/developer/deprecating
![fcp-indi.github.io/docs/nightly/developer/deprecating](https://user-images.githubusercontent.com/5974438/178534546-52fa3498-51db-423c-bcab-95b7e33ed788.png)

### User docs

#### fcp-indi.github.io/docs/nightly/user/quick
![fcp-indi.github.io/docs/nightly/user/quick#download-upgrade-c-pac-with-cpac](https://user-images.githubusercontent.com/5974438/178535297-3cf3dffb-e1a6-47df-afc5-01e42ccaf344.png)

![fcp-indi.github.io/docs/nightly/user/quick#platform-singularity](https://user-images.githubusercontent.com/5974438/178535712-dc3fecc7-012c-4456-9309-372290cbded5.png)

#### fcp-indi.github.io/docs/nightly/user/cpac

![fcp-indi.github.io/docs/nightly/user/cpac#download-upgrade-c-pac-with-cpac](https://user-images.githubusercontent.com/5974438/178536273-6afb89a0-3de0-4c98-9471-c86eba4518c0.png)

#### fcp-indi.github.io/docs/nightly/user/docker

![fcp-indi.github.io/docs/nightly/user/docker](https://user-images.githubusercontent.com/5974438/178536670-1d66075c-080d-4c51-ae15-c10494c8789a.png)

#### fcp-indi.github.io/docs/nightly/user/versions

![fcp-indi.github.io/docs/nightly/user/versions](https://user-images.githubusercontent.com/5974438/178537212-9cfa1594-3fe4-4f1a-afef-bad1ae205a53.png)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).  <!-- If you want to in include a leading emoji, check out https://gitmoji.dev for a pseudo-standard set of options -->
- [x] My pull request targets the `source` branch of the repository. <!-- Change this branch if you're targeting a branch other than `source` -->
- [x] My commit messages follow best practices.
- [x] My code follows the [established code style of the repository](../CONTRIBUTING.md).
- [x] I tried [letting the CI build this branch on a fork or built the project locally](../CONTRIBUTING.md#building) and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
