### PR TITLE
🎨 Hide empty content `<div class="highlight*">` elements

### DIFF
--- a/docs/_sources/_static/custom.css
+++ b/docs/_sources/_static/custom.css
@@ -18,3 +18,9 @@
   width: 100%;
   height: auto;
 }
+
+/* empty content highlight divs ―
+   see 'hideEmptyHighlights.js' */
+div[class*=" highlight"].hidden, div[class^=highlight].hidden {
+	display: none;
+}

--- a/docs/_sources/_static/hideEmptyHighlights.js
+++ b/docs/_sources/_static/hideEmptyHighlights.js
@@ -1,0 +1,9 @@
+/* Hide highlight containers only empty spans */
+document.addEventListener("DOMContentLoaded", function() {
+  const highlightDivs = document.querySelectorAll('div[class^="highlight"], div[class*=" highlight"]');
+  highlightDivs.forEach(function(highlightDiv) {
+    if (highlightDiv.textContent.trim() === '') {
+      highlightDiv.classList.add('hidden');
+    }
+  });
+});

--- a/docs/_sources/conf.py
+++ b/docs/_sources/conf.py
@@ -437,6 +437,7 @@ html_css_files = [
     'custom.css',
 ]
 html_js_files = [
+    'hideEmptyHighlights.js',
     ('versionList.js', {'defer': 'defer'})]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
Working on #308 reminded me how annoying I find the empty-content `<div><div><pre><span>`s that get generated by the `.. exec::` directives that build workflow graphs for the docs, but fixing it seemed out of scope for that PR, so here that is separate.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Those elements are still created, we just add a li'l JS to find the top such `<div>`s https://github.com/FCP-INDI/fcp-indi.github.io/blob/ca758c1937e575f0aa4d27a4547b5c8bcd912bb5/docs/_sources/_static/hideEmptyHighlights.js#L3-L5, add a `"hidden"` class to them https://github.com/FCP-INDI/fcp-indi.github.io/blob/ca758c1937e575f0aa4d27a4547b5c8bcd912bb5/docs/_sources/_static/hideEmptyHighlights.js#L6, and update the custom CSS accordingly https://github.com/FCP-INDI/fcp-indi.github.io/blob/ca758c1937e575f0aa4d27a4547b5c8bcd912bb5/docs/_sources/_static/custom.css#L22-L26 to hide such elements.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
### Before
<img width="557" alt="https://shnizzedy.github.io/fcp-indi.github.io/docs/nightly/developer/workflows/alff" src="https://github.com/FCP-INDI/fcp-indi.github.io/assets/5974438/e2aeead6-e209-471f-b6c8-bef49f658e99">


### After
<img width="555" alt="https://shnizzedy.github.io/fcp-indi.github.io/docs/nightly/developer/workflows/alff" src="https://github.com/FCP-INDI/fcp-indi.github.io/assets/5974438/839b9462-2bab-48e3-a401-948443f5363e">


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).  <!-- If you want to in include a leading emoji, check out https://gitmoji.dev for a pseudo-standard set of options -->
- [x] My pull request targets the `source` branch of the repository. <!-- Change this branch if you're targeting a branch other than `source` -->
- [x] My commit messages follow best practices.
- [x] My code follows the [established code style of the repository](../CONTRIBUTING.md).
- [x] I tried [letting the CI build this branch on a fork or built the project locally](../CONTRIBUTING.md#building) and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
