### PR TITLE
📝 Document FCP-INDI/C-PAC#2115: ⚰️ Remove stale variants

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,6 @@ commands:
           name: 👊 Running cpac commands
           command: |
             source /home/circleci/simple/bin/activate
-            pip install "git+https://git@github.com/docker/docker-py.git@7785ad913ddf2d86478f08278bb2c488d05a29ff"  # until docker/docker-py#3257 is released
             cpac pull
             mkdir -p docs/_sources/user/cpac
             printf ".. code-block:: console\n\n   $ cpac --help\n\n" > docs/_sources/user/cpac/help.rst

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ commands:
           name: 👊 Running cpac commands
           command: |
             source /home/circleci/simple/bin/activate
+            pip install "git+https://git@github.com/docker/docker-py.git@7785ad913ddf2d86478f08278bb2c488d05a29ff"  # until docker/docker-py#3257 is released
             cpac pull
             mkdir -p docs/_sources/user/cpac
             printf ".. code-block:: console\n\n   $ cpac --help\n\n" > docs/_sources/user/cpac/help.rst
@@ -187,7 +188,6 @@ jobs:
       - deploy
 
 workflows:
-  version: 2.1
   build_and_deploy:
     jobs:
       - build-nightly:

--- a/docs/_sources/conf.py
+++ b/docs/_sources/conf.py
@@ -13,6 +13,7 @@
 # serve to show the default.
 
 import os
+from pathlib import Path
 import re
 import sys
 from typing import Any
@@ -32,8 +33,12 @@ from pybtex.plugin import register_plugin
 sys.path.append(os.path.dirname(__file__))
 
 from references import CPAC_DocsStyle  # noqa: E402
+from docker_hub_info import update_doc
 
 register_plugin('pybtex.style.formatting', 'cpac_docs_style', CPAC_DocsStyle)
+
+# Update Docker Hub links
+update_doc(Path(__file__).parent / "user/versions.rst")
 
 # "Dealing with Invalid Versions" from
 # https://python-semver.readthedocs.io/en/latest/usage.html

--- a/docs/_sources/conf.py
+++ b/docs/_sources/conf.py
@@ -593,7 +593,7 @@ rst_prolog = """
 .. |version as code| replace:: ``{version}``
 
 """.format(
-    version=f'v{version}' if not version.endswith('dev') else 'nightly'
+    version=f'release-v{version}' if not version.endswith('dev') else 'nightly'
 )
 
 rst_epilog = """

--- a/docs/_sources/conf.py
+++ b/docs/_sources/conf.py
@@ -154,7 +154,7 @@ sys.path.insert(0, os.path.abspath('.'))
 # -- General configuration ----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-# needs_sphinx = '1.0'
+needs_sphinx = '7.3'
 #
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions

--- a/docs/_sources/docker_hub_info.py
+++ b/docs/_sources/docker_hub_info.py
@@ -1,0 +1,55 @@
+"""Get link info for links to Docker Hub."""
+from pathlib import Path
+import requests
+
+
+def digest(tag_data: dict) -> str:
+    """Return a tag's digest if it exists."""
+    return tag_data.get("images", [{}])[0].get("digest", "")
+
+
+def get_latest_tags() -> tuple[str, str, str]:
+    """Return a list of tags from Docker Hub.
+    
+    Returns
+    -------
+    latest_tag
+    
+    latest-lite_tag
+    """
+    url = "https://hub.docker.com/v2/repositories/fcpindi/c-pac/tags?page_size=100"
+    response = requests.get(url)
+    tags_data = response.json()
+    tags = {tag["name"]: tag for tag in tags_data.get("results", []) if tag["name"].startswith("release-")}
+    tag_keys = list(tags.keys())
+    tag_keys.sort(reverse=True)
+    latest, lite = next(tag for tag in tag_keys if tag[-1].isdigit()), next(tag for tag in tag_keys if tag.endswith("-lite"))
+    return ("primary", latest, digest(tags[latest])), ("lite", lite, digest(tags[lite]))
+
+
+def create_badge(variant: str, tag: str, digest: str) -> dict[str, str]:
+    """Create a Docker Hub RST badge for the given tag and digest."""
+    version = tag.split("-v", 1)[1].split("-", 1)[0]
+    repstr = f"|latest-{variant}-badge|"
+    return {repstr: f""".. {repstr} image:: https://img.shields.io/badge/last_published_version-C--PAC_{version}-green
+   :target: https://hub.docker.com/layers/fcpindi/c-pac/{tag}/images/{digest.replace(':', '-')}
+"""}
+
+
+def update_doc(doc_path: Path) -> None:
+    r"""Update the badges in ``docs_path``."""
+    badges = {}
+    for tag in get_latest_tags():
+        badges.update(create_badge(*tag))
+    with doc_path.open("r", encoding="utf8") as _doc:
+        lines = _doc.readlines()
+    for i, line in enumerate(lines):
+        if line.startswith(".. |"):
+            for key, badge in badges.items():
+                if line.startswith(f".. {key}"):
+                    lines[i:i+2] = badge
+    with doc_path.open("w", encoding="utf8") as _doc:
+        _doc.write("".join(lines))
+
+if __name__ == "__main__":
+    update_doc(Path(__file__).parent / "user/versions.rst")

--- a/docs/_sources/user/versions.rst
+++ b/docs/_sources/user/versions.rst
@@ -9,14 +9,14 @@ Variants
 Primary image
 -------------
 
-|latest-primary-badge|
+|latest-primary-badge| |nightly-badge|
 
 Non-variant, primary image (no ``${VARIANT}`` or an empty string, e.g. |example version|)
 
 Lite variant
 ------------
 
-|latest-lite-badge|
+|latest-lite-badge| |nightly-lite-badge|
 
 ``-lite``, primary image without FreeSurfer for a smaller image for runs that don't need FreeSurfer (e.g., |example version|\ ``-lite``)
 
@@ -52,3 +52,10 @@ fMRIPrep-LTS variant
 
 .. |latest-lite-badge| image:: https://img.shields.io/badge/last_published_version-C--PAC_1.8.7-green
    :target: https://hub.docker.com/layers/fcpindi/c-pac/release-v1.8.7-lite/images/sha256-7e983fdf82a005509c96cee3aa90755e2783d9c8835a46cabacf94540ddb9f3a
+
+.. |nightly-badge| image:: https://img.shields.io/badge/last_development_version-C--PAC_nightly-green
+   :target: https://hub.docker.com/layers/fcpindi/c-pac/nightly/images/sha256-779c148e491dda7120dbf5b667bf7d86e81282d56fae67c5d3c5be2ecd6618b0
+   
+.. |nightly-lite-badge| image:: https://img.shields.io/badge/last_development_version-C--PAC_nightly-green
+   :target: https://hub.docker.com/layers/fcpindi/c-pac/nightly-lite/images/sha256-2cbbc07e601f1530846143ccb74ff6b8e64f04f7f19ff7f84ff8dcc5c91be639
+   

--- a/docs/_sources/user/versions.rst
+++ b/docs/_sources/user/versions.rst
@@ -30,10 +30,10 @@ ABCD-HCP variant
 
 .. versionremoved:: 1.8.8
 
-.. image:: https://img.shields.io/badge/last_published_version-C--PAC_1.8.7_%7C_abcd--hcp--pipeline@e480a8f-yellow
+.. image:: https://img.shields.io/badge/last_published_version-C--PAC_1.8.7_%7C_abcd--hcp--pipeline_0.1.4-yellow
    :target: https://hub.docker.com/layers/fcpindi/c-pac/release-v1.8.7-ABCD-HCP/images/sha256-859bd8b11c38f07f53c75c7d06543bc3f35aa7ec368bb2ac0d9362ba365fe90e
 
-``-ABCD-HCP``, image with software dependencies version-matched to `ABCD-HCP BIDS fMRI Pipeline <https://github.com/DCAN-Labs/abcd-hcp-pipeline/blob/e480a8f99534f1b05f37bf44c64827384b69b383/Dockerfile>`_ (e.g., ``release-v1.8.7-ABCD-HCP``)
+``-ABCD-HCP``, image with software dependencies version-matched to `ABCD-HCP BIDS fMRI Pipeline <https://github.com/DCAN-Labs/abcd-hcp-pipeline/blob/e480a8f99534f1b05f37bf44c64827384b69b383/Dockerfile>`_ version `0.1.4 <https://github.com/DCAN-Labs/abcd-hcp-pipeline/releases/tag/v0.1.4>`_ (e.g., ``release-v1.8.7-ABCD-HCP``)
 
 fMRIPrep-LTS variant
 ********************
@@ -43,7 +43,7 @@ fMRIPrep-LTS variant
 .. image:: https://img.shields.io/badge/last_published_version-C--PAC_1.8.7_%7C_fMRIPrep--LTS_20.2.1-yellow
    :target: https://hub.docker.com/layers/fcpindi/c-pac/release-v1.8.7-fMRIPrep-LTS/images/sha256-cf30cb0643477f01067db9bd173f425f891644e0c0103cf754e1aa5e2b000938
 
-``-fMRIPrep-LTS``, image with software dependencies version-matched to `fMRIPrep LTS <https://reproducibility.stanford.edu/fmriprep-lts#long-term-support-lts>`_ (e.g., ``release-v1.8.7-fMRIPrep-LTS``)
+``-fMRIPrep-LTS``, image with software dependencies version-matched to `fMRIPrep LTS <https://reproducibility.stanford.edu/fmriprep-lts#long-term-support-lts>`_ version `20.2.1 <https://github.com/nipreps/fmriprep/releases/tag/20.2.1>`_ (e.g., ``release-v1.8.7-fMRIPrep-LTS``)
 
 .. |example version| replace:: |version as code|
 

--- a/docs/_sources/user/versions.rst
+++ b/docs/_sources/user/versions.rst
@@ -9,21 +9,46 @@ Variants
 Primary image
 -------------
 
+|latest-primary-badge|
+
 Non-variant, primary image (no ``${VARIANT}`` or an empty string, e.g. |example version|)
 
 Lite variant
 ------------
 
+|latest-lite-badge|
+
 ``-lite``, primary image without FreeSurfer for a smaller image for runs that don't need FreeSurfer (e.g., |example version|\ ``-lite``)
 
+Stale variants
+--------------
+
+The following variants were version-matched to other pipelines years ago but have not been recently harmonized.
+
 ABCD-HCP variant
-----------------
+****************
+
+.. versionremoved:: 1.8.8
+
+.. image:: https://img.shields.io/badge/last_published_version-C--PAC_1.8.7_%7C_abcd--hcp--pipeline@e480a8f-yellow
+   :target: https://hub.docker.com/layers/fcpindi/c-pac/release-v1.8.7-ABCD-HCP/images/sha256-859bd8b11c38f07f53c75c7d06543bc3f35aa7ec368bb2ac0d9362ba365fe90e
 
 ``-ABCD-HCP``, image with software dependencies version-matched to `ABCD-HCP BIDS fMRI Pipeline <https://github.com/DCAN-Labs/abcd-hcp-pipeline/blob/e480a8f99534f1b05f37bf44c64827384b69b383/Dockerfile>`_ (e.g., |example version|\ ``-ABCD-HCP``)
 
 fMRIPrep-LTS variant
---------------------
+********************
+
+.. versionremoved:: 1.8.8
+
+.. image:: https://img.shields.io/badge/last_published_version-C--PAC_1.8.7_%7C_fMRIPrep--LTS_20.2.1-yellow
+   :target: https://hub.docker.com/layers/fcpindi/c-pac/release-v1.8.7-fMRIPrep-LTS/images/sha256-cf30cb0643477f01067db9bd173f425f891644e0c0103cf754e1aa5e2b000938
 
 ``-fMRIPrep-LTS``, image with software dependencies version-matched to `fMRIPrep LTS <https://reproducibility.stanford.edu/fmriprep-lts#long-term-support-lts>`_ (e.g., |example version|\ ``-fMRIPrep-LTS``)
 
 .. |example version| replace:: ``release-``\ |version as code|
+
+.. |latest-primary-badge| image:: https://img.shields.io/badge/last_published_version-C--PAC_1.8.7-green
+   :target: https://hub.docker.com/layers/fcpindi/c-pac/release-v1.8.7/images/sha256-590200a9f6b87e4c67a7b19627f332d54fab94a54c0fc5ed709d6fa31017569f
+
+.. |latest-lite-badge| image:: https://img.shields.io/badge/last_published_version-C--PAC_1.8.7-green
+   :target: https://hub.docker.com/layers/fcpindi/c-pac/release-v1.8.7-lite/images/sha256-7e983fdf82a005509c96cee3aa90755e2783d9c8835a46cabacf94540ddb9f3a

--- a/docs/_sources/user/versions.rst
+++ b/docs/_sources/user/versions.rst
@@ -33,7 +33,7 @@ ABCD-HCP variant
 .. image:: https://img.shields.io/badge/last_published_version-C--PAC_1.8.7_%7C_abcd--hcp--pipeline@e480a8f-yellow
    :target: https://hub.docker.com/layers/fcpindi/c-pac/release-v1.8.7-ABCD-HCP/images/sha256-859bd8b11c38f07f53c75c7d06543bc3f35aa7ec368bb2ac0d9362ba365fe90e
 
-``-ABCD-HCP``, image with software dependencies version-matched to `ABCD-HCP BIDS fMRI Pipeline <https://github.com/DCAN-Labs/abcd-hcp-pipeline/blob/e480a8f99534f1b05f37bf44c64827384b69b383/Dockerfile>`_ (e.g., |example version|\ ``-ABCD-HCP``)
+``-ABCD-HCP``, image with software dependencies version-matched to `ABCD-HCP BIDS fMRI Pipeline <https://github.com/DCAN-Labs/abcd-hcp-pipeline/blob/e480a8f99534f1b05f37bf44c64827384b69b383/Dockerfile>`_ (e.g., ``release-v1.8.7-ABCD-HCP``)
 
 fMRIPrep-LTS variant
 ********************
@@ -43,9 +43,9 @@ fMRIPrep-LTS variant
 .. image:: https://img.shields.io/badge/last_published_version-C--PAC_1.8.7_%7C_fMRIPrep--LTS_20.2.1-yellow
    :target: https://hub.docker.com/layers/fcpindi/c-pac/release-v1.8.7-fMRIPrep-LTS/images/sha256-cf30cb0643477f01067db9bd173f425f891644e0c0103cf754e1aa5e2b000938
 
-``-fMRIPrep-LTS``, image with software dependencies version-matched to `fMRIPrep LTS <https://reproducibility.stanford.edu/fmriprep-lts#long-term-support-lts>`_ (e.g., |example version|\ ``-fMRIPrep-LTS``)
+``-fMRIPrep-LTS``, image with software dependencies version-matched to `fMRIPrep LTS <https://reproducibility.stanford.edu/fmriprep-lts#long-term-support-lts>`_ (e.g., ``release-v1.8.7-fMRIPrep-LTS``)
 
-.. |example version| replace:: ``release-``\ |version as code|
+.. |example version| replace:: |version as code|
 
 .. |latest-primary-badge| image:: https://img.shields.io/badge/last_published_version-C--PAC_1.8.7-green
    :target: https://hub.docker.com/layers/fcpindi/c-pac/release-v1.8.7/images/sha256-590200a9f6b87e4c67a7b19627f332d54fab94a54c0fc5ed709d6fa31017569f
@@ -53,9 +53,9 @@ fMRIPrep-LTS variant
 .. |latest-lite-badge| image:: https://img.shields.io/badge/last_published_version-C--PAC_1.8.7-green
    :target: https://hub.docker.com/layers/fcpindi/c-pac/release-v1.8.7-lite/images/sha256-7e983fdf82a005509c96cee3aa90755e2783d9c8835a46cabacf94540ddb9f3a
 
-.. |nightly-badge| image:: https://img.shields.io/badge/last_development_version-C--PAC_nightly-green
+.. |nightly-badge| image:: https://img.shields.io/badge/development_version-C--PAC_nightly-green
    :target: https://hub.docker.com/layers/fcpindi/c-pac/nightly/images/sha256-779c148e491dda7120dbf5b667bf7d86e81282d56fae67c5d3c5be2ecd6618b0
-   
-.. |nightly-lite-badge| image:: https://img.shields.io/badge/last_development_version-C--PAC_nightly-green
+      
+.. |nightly-lite-badge| image:: https://img.shields.io/badge/development_version-C--PAC_nightly-green
    :target: https://hub.docker.com/layers/fcpindi/c-pac/nightly-lite/images/sha256-2cbbc07e601f1530846143ccb74ff6b8e64f04f7f19ff7f84ff8dcc5c91be639
-   
+      

--- a/docs/_sources/user/versions.rst
+++ b/docs/_sources/user/versions.rst
@@ -28,7 +28,7 @@ The following variants were version-matched to other pipelines years ago but hav
 ABCD-HCP variant
 ****************
 
-.. versionremoved:: 1.8.8
+.. versionremoved:: 1.8.7.post1
 
 .. image:: https://img.shields.io/badge/last_published_version-C--PAC_1.8.7_%7C_abcd--hcp--pipeline_0.1.4-yellow
    :target: https://hub.docker.com/layers/fcpindi/c-pac/release-v1.8.7-ABCD-HCP/images/sha256-859bd8b11c38f07f53c75c7d06543bc3f35aa7ec368bb2ac0d9362ba365fe90e
@@ -38,7 +38,7 @@ ABCD-HCP variant
 fMRIPrep-LTS variant
 ********************
 
-.. versionremoved:: 1.8.8
+.. versionremoved:: 1.8.7.post1
 
 .. image:: https://img.shields.io/badge/last_published_version-C--PAC_1.8.7_%7C_fMRIPrep--LTS_20.2.1-yellow
    :target: https://hub.docker.com/layers/fcpindi/c-pac/release-v1.8.7-fMRIPrep-LTS/images/sha256-cf30cb0643477f01067db9bd173f425f891644e0c0103cf754e1aa5e2b000938

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,11 +8,13 @@ m2r
 mistune==0.8.4
 nbsphinx
 PyGithub
-sphinx==7.1.2
+sphinx==7.3.2
+sphinx-basic-ng>=1.0.0.beta2
 sphinxcontrib-bibtex==2.5.0
 sphinxcontrib-jquery>=4.1
 sphinxcontrib-programoutput
 sphinx-issues>=4.1.0
 semver
+tomli>=2; python_version < '3.11'
 torch
 furo


### PR DESCRIPTION
## Documents
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Documents #[issue number]" to "Documents #1". -->
Documents FCP-INDI/C-PAC#2115 by @shnizzedy

## Description
<!-- Concisely describe what the pull request does. -->

In [C-PAC documentation » C-PAC versions](https://fcp-indi.github.io/docs/nightly/user/versions):
- Moves `-ABCD-HCP` and `-fMRIPrep-LTS` variants into a "Stale variants" section with a 
  > The following variants were version-matched to other pipelines years ago but have not been recently harmonized.
  
  preamble.
- Adds `.. versionremoved:: 1.8.7.post1` to each of these stale variants' documentation
- Adds a "last published version" badge to the documentation for the primary and each of the variant images (and a "development version" badge to the primary and `-lite` variant). These badges link to the page for the image on Docker Hub.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
- The `.. versionremoved::` directive wasn't added to Sphinx until 7.3, so this PR also upgrades Sphinx (to 7.3.2 to include a fix for the theme we're using)
- This PR includes code to automate updating the badges for non-stale images.
  - In this PR, the code is called [in `conf.py`](https://github.com/FCP-INDI/fcp-indi.github.io/blob/8561711825e39681678855d05990c0dcf3afbe31/docs/_sources/conf.py#L40-L41) https://github.com/FCP-INDI/fcp-indi.github.io/blob/8561711825e39681678855d05990c0dcf3afbe31/docs/_sources/conf.py#L40-L41
  - In the future, we might want to move (or also run) it to pre-commit or to the CI to make the changes persist instead of (or in addition to) at build time, to make the changes persist in the source document.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

### before this PR
![screenshot of fcp-indi.github.io/docs/nightly/user/versions](https://github.com/FCP-INDI/fcp-indi.github.io/assets/5974438/d4da0d3b-b41c-4f93-a045-efabb5f571d9)


### with this PR
![screenshot of fcp-indi.github.io/docs/nightly/user/versions](https://github.com/FCP-INDI/fcp-indi.github.io/assets/5974438/ec834677-6315-427a-a79d-efc044496df5)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).  <!-- If you want to in include a leading emoji, check out https://gitmoji.dev for a pseudo-standard set of options -->
- [x] My pull request targets the `source` branch of the repository. <!-- Change this branch if you're targeting a branch other than `source` -->
- [x] My commit messages follow best practices.
- [x] My code follows the [established code style of the repository](../CONTRIBUTING.md).
- [x] I tried [letting the CI build this branch on a fork or built the project locally](../CONTRIBUTING.md#building) and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
