### PR TITLE
📝 Document "📦️ Restore `bids-validator` installation in containerized C-PAC images (FCP-INDI/C-PAC#2120)"

### DIFF
--- a/docs/_sources/conf.py
+++ b/docs/_sources/conf.py
@@ -149,7 +149,7 @@ sys.path.insert(0, os.path.abspath('.'))
 # -- General configuration ----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-# needs_sphinx = '1.0'
+needs_sphinx = '7.3'
 #
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions

--- a/docs/_sources/user/help.rst
+++ b/docs/_sources/user/help.rst
@@ -45,11 +45,6 @@ where :file:`crash-file.pklz` is the name of the crash file you wish to view.
 Common Issues
 ^^^^^^^^^^^^^
 
-``bids-validator: command not found``
--------------------------------------
-
-.. include:: /user/known-issues/FCP-INDI/C-PAC/2110.rst
-
 My end-to-end surface pipeline with ABCD post-processing is hanging/stalling.
 -----------------------------------------------------------------------------
 
@@ -82,3 +77,11 @@ How should I cite C-PAC in my paper?
 ------------------------------------
 
 Please cite the abstract located `here <http://www.frontiersin.org/10.3389/conf.fninf.2013.09.00042/event_abstract>`__.
+
+Recently Resolved Common Issues
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``bids-validator: command not found``
+-------------------------------------
+
+.. include:: /user/known-issues/FCP-INDI/C-PAC/2110.rst

--- a/docs/_sources/user/known-issues/FCP-INDI/C-PAC/2110.rst
+++ b/docs/_sources/user/known-issues/FCP-INDI/C-PAC/2110.rst
@@ -6,21 +6,8 @@
 
 .. versionadded:: 1.8.6
 
-See issue :issue:`2110` for the latest developments on this issue.
+.. versionremoved:: 1.8.8
 
-When running C-PAC with an input BIDS directory, no data configuration file and without the ``--skip_bids_validator`` flag, C-PAC will crash with a ``bids-validator: command not found`` message.
+Issue :issue:`2110` resolved in :issue:`2120`
 
-Workarounds
-###########
-
-Either of these workarounds should allow you to run versions of C-PAC affected by this issue:
-
-- Add the ``--skip_bids_validator`` flag to your run command. If desired, run the `BIDS validator`_ on your input data prior to using C-PAC.
-- Use a :doc:`data configuration file </user/subject_list_config>` to specify your input data.
-
-Planned resolution
-``````````````````
-
-- Restoring or replacing ``bids-validator`` in an upcoming version of C-PAC.
-
-.. _BIDS validator: https://github.com/bids-standard/bids-validator#readme
+When running C-PAC with an input BIDS directory, no data configuration file and without the ``--skip_bids_validator`` flag, C-PAC would crash with a ``bids-validator: command not found`` message. The ``bids-validator`` CLI was restored to the C-PAC container images in version 1.8.8.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,11 +8,13 @@ m2r
 mistune==0.8.4
 nbsphinx
 PyGithub
-sphinx==7.1.2
+sphinx==7.3.2
+sphinx-basic-ng>=1.0.0.beta2
 sphinxcontrib-bibtex==2.5.0
 sphinxcontrib-jquery>=4.1
 sphinxcontrib-programoutput
 sphinx-issues>=4.1.0
 semver
+tomli>=2; python_version < '3.11'
 torch
 furo


### PR DESCRIPTION
## Documents
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Documents #[issue number]" to "Documents #1". -->
Documents FCP-INDI/C-PAC#2120 by @shnizzedy 
Documents resolution of FCP-INDI/C-PAC#2110 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->

* Moves FCP-INDI/C-PAC#2110 documentation from "Common Issues" to "Recently Resolved Common Issues"
* Adds annotation that issue was resolved in C-PAC v1.8.8
* Replaces language about workarounds with
  > The `bids-validator` CLI was restored to the C-PAC container images in version 1.8.8.


## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

Includes 57d4544 ("⬆️ Upgrade 𓂀 Sphinx@7.3") from #323 for 
> The `.. versionremoved::` directive wasn't added to Sphinx until 7.3, so this PR also upgrades Sphinx (to 7.3.2 to include a fix for the theme we're using)

  ― https://github.com/FCP-INDI/fcp-indi.github.io/pull/323#issue-2313499743

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

### `fcp-indi.github.io/docs/nightly/user/help#recently-resolved-common-issues`

<img width="760" alt="screenshot of `https://fcp-indi.github.io/docs/nightly/user/help#recently-resolved-common-issues`" src="https://github.com/FCP-INDI/fcp-indi.github.io/assets/5974438/1fec442c-feee-4c67-85d6-28c973948846">


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).  <!-- If you want to in include a leading emoji, check out https://gitmoji.dev for a pseudo-standard set of options -->
- [x] My pull request targets the `source` branch of the repository. <!-- Change this branch if you're targeting a branch other than `source` -->
- [x] My commit messages follow best practices.
- [x] My code follows the [established code style of the repository](../CONTRIBUTING.md).
- [x] I tried [letting the CI build this branch on a fork or built the project locally](../CONTRIBUTING.md#building) and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
