### PR TITLE
📝 Document "♻️ Split `ResourcePool` into three classes"

### DIFF
--- a/docs/_sources/_templates/layout.html
+++ b/docs/_sources/_templates/layout.html
@@ -1,5 +1,9 @@
 {% extends "!layout.html" %}
-
+{%- block scripts %}
+    {{ super() }}
+    <script src="{{ pathto('assets/js/jquery.min.js', 1) }}"></script>
+    <script src="{{ pathto('_static/underscore.js', 1) }}"></script>
+{%- endblock %}
 {% block footer %}
 {{ super() }}
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19224662-10"></script>

--- a/docs/_sources/autodoc_nodeblock.py
+++ b/docs/_sources/autodoc_nodeblock.py
@@ -1,5 +1,5 @@
 from typing import TYPE_CHECKING, Any
-from CPAC.pipeline.nodeblock import NodeBlockFunction
+from CPAC.pipeline.engine.nodeblock import NodeBlockFunction
 from docutils.statemachine import StringList
 from sphinx.ext.autodoc import Documenter, FunctionDocumenter, bool_option
 

--- a/docs/_sources/conf.py
+++ b/docs/_sources/conf.py
@@ -19,7 +19,7 @@ from typing import Any
 
 from dateutil import parser as dparser
 from CPAC import __version__
-from CPAC.pipeline.nodeblock import NodeBlockFunction
+from CPAC.pipeline.engine.nodeblock import NodeBlockFunction
 from CPAC.utils.monitoring import custom_logging
 from github import Github
 from github.GithubException import RateLimitExceededException, \

--- a/docs/_sources/conf.py
+++ b/docs/_sources/conf.py
@@ -172,6 +172,7 @@ extensions = [
 add_module_names = False
 maximum_signature_line_length = 90
 
+autoclass_content = "both"
 autodoc_typehints = "both"
 autodoc_typehints_format = "short"
 

--- a/docs/_sources/conf.py
+++ b/docs/_sources/conf.py
@@ -169,6 +169,12 @@ extensions = [
     'exec',
     'nbsphinx']
 
+add_module_names = False
+maximum_signature_line_length = 90
+
+autodoc_typehints = "both"
+autodoc_typehints_format = "short"
+
 bibtex_bibfiles = [f'references/{bib}' for bib in os.listdir('references') if
                    bib.endswith('.bib')]
 bibtex_default_style = 'cpac_docs_style'
@@ -179,7 +185,11 @@ intersphinx_mapping = {
 
 issues_github_path = 'FCP-INDI/C-PAC'
 
+napoleon_attr_annotations = True
+napoleon_include_private_with_doc = True
 napoleon_preprocess_types = True
+napoleon_use_admonition_for_notes = True
+
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/_sources/developer/logging.rst
+++ b/docs/_sources/developer/logging.rst
@@ -26,7 +26,6 @@ A ``CPAC.utils.monitoring.custom_logging.MockLogger`` can be used in place of a 
 .. autofunction:: CPAC.utils.monitoring.custom_logging.getLogger
 
 .. autoclass:: CPAC.utils.monitoring.custom_logging.MockLogger
-   :special-members: __init__
    :members:
    :inherited-members:
 

--- a/docs/_sources/developer/nodes.rst
+++ b/docs/_sources/developer/nodes.rst
@@ -30,17 +30,14 @@ For nodes that will use a varying amount of memory depending on the node's input
 
 
 .. autoclass:: CPAC.pipeline.nipype_pipeline_engine.Node
-   :special-members: __init__
    :members:
    :inherited-members:
 
 .. autoclass:: CPAC.pipeline.nipype_pipeline_engine.MapNode
-   :special-members: __init__
    :members:
    :inherited-members:
 
 .. autoclass:: nipype.interfaces.base.core.Interface
-   :special-members: __init__
    :members:
    :inherited-members:
 
@@ -50,12 +47,10 @@ For nodes that will use a varying amount of memory depending on the node's input
 
 
 .. autoclass:: CPAC.utils.interfaces.function.Function
-   :special-members: __init__
    :members:
    :inherited-members:
 
 .. autoclass:: CPAC.pipeline.nipype_pipeline_engine.Workflow
-   :special-members: __init__
    :members:
    :inherited-members:
 

--- a/docs/_sources/developer/pipeline.rst
+++ b/docs/_sources/developer/pipeline.rst
@@ -3,6 +3,23 @@ Pipeline Development
 
 .. include:: /developer/schema.rst
 
+Engine
+^^^^^^
+
+NodeBlock
+---------
+
+.. automodule:: CPAC.pipeline.engine.nodeblock
+    :members:
+    :undoc-members:
+
+Resource
+--------
+
+.. automodule:: CPAC.pipeline.engine.resource
+    :members:
+    :undoc-members:
+
 Pipeline Utilities
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/_sources/developer/pipeline.rst
+++ b/docs/_sources/developer/pipeline.rst
@@ -11,6 +11,8 @@ NodeBlock
 
 .. automodule:: CPAC.pipeline.engine.nodeblock
     :members:
+    :special-members:
+    :private-members:
     :undoc-members:
 
 Resource
@@ -18,6 +20,8 @@ Resource
 
 .. automodule:: CPAC.pipeline.engine.resource
     :members:
+    :special-members:
+    :private-members:
     :undoc-members:
 
 Pipeline Utilities

--- a/docs/_sources/developer/pipeline.rst
+++ b/docs/_sources/developer/pipeline.rst
@@ -24,6 +24,15 @@ Resource
     :private-members:
     :undoc-members:
 
+Tests
+-----
+
+.. automodule:: CPAC.pipeline.test.test_engine
+    :members:
+    :special-members:
+    :private-members:
+    :undoc-members:
+
 Pipeline Utilities
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/_sources/developer/pipeline.rst
+++ b/docs/_sources/developer/pipeline.rst
@@ -11,7 +11,7 @@ NodeBlock
 
 .. automodule:: CPAC.pipeline.engine.nodeblock
     :members:
-    :special-members:
+    :inherited-members:
     :private-members:
     :undoc-members:
 
@@ -20,7 +20,7 @@ Resource
 
 .. automodule:: CPAC.pipeline.engine.resource
     :members:
-    :special-members:
+    :inherited-members:
     :private-members:
     :undoc-members:
 
@@ -29,7 +29,7 @@ Tests
 
 .. automodule:: CPAC.pipeline.test.test_engine
     :members:
-    :special-members:
+    :inherited-members:
     :private-members:
     :undoc-members:
 
@@ -38,4 +38,5 @@ Pipeline Utilities
 
 .. automodule:: CPAC.pipeline.utils
     :members:
+    :inherited-members:
     :undoc-members:

--- a/docs/_sources/developer/schema.rst
+++ b/docs/_sources/developer/schema.rst
@@ -1,8 +1,7 @@
 .. _validation_schema:
 
-*****************
 Validation Schema
-*****************
+^^^^^^^^^^^^^^^^^
 
 C-PAC uses `voluptuous <alecthomas.github.io/voluptuous/docs/_build/html>`_ to validate pipeline configurations against defined types and value restrictions. Default values should be set in :doc:`the default pipeline </user/pipelines/default>` along with comments explaining each option.
 

--- a/docs/_sources/developer/workflows/network_centrality.rst
+++ b/docs/_sources/developer/workflows/network_centrality.rst
@@ -2,19 +2,16 @@ Network Centrality
 ==================
 
 .. automodule:: CPAC.network_centrality.network_centrality
-   :special-members: __init__
    :members:
    :private-members:
    :undoc-members:
 
 .. automodule:: CPAC.network_centrality.pipeline
-   :special-members: __init__
    :members:
    :private-members:
    :undoc-members:
 
 .. automodule:: CPAC.network_centrality.utils
-   :special-members: __init__
    :members:
    :private-members:
    :undoc-members:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ m2r
 mistune==0.8.4
 nbsphinx
 PyGithub
+pytest
 sphinx==7.3.2
 sphinx-basic-ng>=1.0.0.beta2
 sphinxcontrib-bibtex==2.5.0


### PR DESCRIPTION
## Documents
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Documents #[issue number]" to "Documents #1". -->
Documents FCP-INDI/C-PAC#2131 by @shnizzedy

## Description
<!-- Concisely describe what the pull request does. -->
Inserts Engine: NodeBlock, Resource, Tests between "Validation Schema" and "Pipeline Utilities" in "[C-PAC nightly documentation » Developer Documentation » Pipeline Development](https://fcp-indi.github.io/docs/nightly/developer/pipeline)"

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

Includes a few formatting tweaks:

1. Fixes the heading level for "[Validation Schema](https://fcp-indi.github.io/docs/nightly/developer/pipeline#validation-schema)".
2. Sets just-the-object-name as the default (as opposed to fully-qualified-object-names).
3. If signatures > 90 characters, give one parameter per line instead of all on one line.
4. Include `__init__` signature in class documentation.
5. Show typehints in both the signature and the content of each docstring.
6. Installs Pytest as part of docbuilding to autodoc tests.

## Screenshot
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

![fcp-indi.github.io/docs/nightly/developer/pipeline#engine](https://github.com/user-attachments/assets/19bda6b8-89f5-4487-8121-e5ff6ec0a0ae)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).  <!-- If you want to in include a leading emoji, check out https://gitmoji.dev for a pseudo-standard set of options -->
- [x] My pull request targets the `source` branch of the repository. <!-- Change this branch if you're targeting a branch other than `source` -->
- [x] My commit messages follow best practices.
- [x] My code follows the [established code style of the repository](../CONTRIBUTING.md).
- [x] I tried [letting the CI build this branch on a fork or built the project locally](../CONTRIBUTING.md#building) and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
