### PR TITLE
📝 Update `FROM` base from `default` to `blank`

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,11 +1,18 @@
 #!/bin/bash
 
 # link references
-CPAC_DIRECTORY=$(python -c "import os, CPAC; print(os.path.abspath(os.path.dirname(CPAC.__file__)))")
-ln ${CPAC_DIRECTORY}/resources/configs/1.7-1.8-nesting-mappings.yml docs/_sources/references/1.7-1.8-nesting-mappings.yml || true
-ln ${CPAC_DIRECTORY}/resources/configs/1.7-1.8-deprecations.yml docs/_sources/references/1.7-1.8-deprecations.yml || true
-ln ${CPAC_DIRECTORY}/resources/configs/pipeline_config_default.yml docs/_sources/references/default_pipeline.yml || true
-ln ${CPAC_DIRECTORY}/resources/configs/group_config_template.yml docs/_sources/references/group_config_template.yml || true
+CPAC_DIRECTORY=$(python -c "from importlib import resources; print(str(resources.files('CPAC')))")
+ln "${CPAC_DIRECTORY}/resources/configs/1.7-1.8-nesting-mappings.yml" docs/_sources/references/1.7-1.8-nesting-mappings.yml || true
+ln "${CPAC_DIRECTORY}/resources/configs/1.7-1.8-deprecations.yml" docs/_sources/references/1.7-1.8-deprecations.yml || true
+shopt -s globstar nullglob
+for PRECONFIG in "${CPAC_DIRECTORY}"/resources/configs/pipeline_config_*.yml
+do
+    FILENAME=$(basename "$PRECONFIG")
+    CONFIG_NAME="${FILENAME#pipeline_config_}"
+    CONFIG_NAME="${CONFIG_NAME%.yml}"
+    ln "${PRECONFIG}" "docs/_sources/references/${CONFIG_NAME}_pipeline.yml" || true
+done
+ln "${CPAC_DIRECTORY}/resources/configs/group_config_template.yml" docs/_sources/references/group_config_template.yml || true
 
 # build docs
-sphinx-build -b html docs/_sources docs/$1
+sphinx-build -b html docs/_sources "docs/$1"

--- a/bin/build
+++ b/bin/build
@@ -10,6 +10,7 @@ do
     FILENAME=$(basename "$PRECONFIG")
     CONFIG_NAME="${FILENAME#pipeline_config_}"
     CONFIG_NAME="${CONFIG_NAME%.yml}"
+    echo "ln \"${PRECONFIG}\" \"docs/_sources/references/${CONFIG_NAME}_pipeline.yml\" || true"
     ln "${PRECONFIG}" "docs/_sources/references/${CONFIG_NAME}_pipeline.yml" || true
 done
 ln "${CPAC_DIRECTORY}/resources/configs/group_config_template.yml" docs/_sources/references/group_config_template.yml || true

--- a/docs/_sources/conf.py
+++ b/docs/_sources/conf.py
@@ -13,6 +13,7 @@
 # serve to show the default.
 
 import os
+from pathlib import Path
 import re
 import sys
 from typing import Any
@@ -28,6 +29,7 @@ import m2r
 from nipype import __version__ as _nipype_version
 import semver
 from pybtex.plugin import register_plugin
+import yaml
 
 sys.path.append(os.path.dirname(__file__))
 
@@ -139,7 +141,29 @@ def yaml_to_rst(path):
     open(path, 'w').write(''.join(lines))
 
 
+def literal_include_config_page(filepath: Path) -> None:
+    """Create a page with a literalinclude of a config file."""
+    if not filepath.exists():
+        return
+    with filepath.open("r", encoding="utf8") as _f:
+        config: dict[str, Any] = yaml.safe_load(_f)
+    title: str = config["pipeline_setup"]["pipeline_name"]
+    with (Path("user/pipelines") /
+          filepath.name.replace("_pipeline.yml", ".rst")
+          ).open("w", encoding="utf8") as _f:
+        _f.write(f""".. title:: {title} pipeline configuration YAML file
+
+.. literalinclude:: /{filepath}
+   :language: YAML
+""")
+    return
+
+
 yaml_to_rst('references/1.7-1.8-deprecations.yml')
+for ref in Path("references").iterdir():
+    if str(ref).endswith("_pipeline.yml"):
+        # create literalinclude page
+        literal_include_config_page(ref)
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/docs/_sources/developer/utils.rst
+++ b/docs/_sources/developer/utils.rst
@@ -22,6 +22,18 @@ Configuration
     :members:
     :undoc-members:
 
+.. automodule:: CPAC.utils.configuration.configuration
+    :members:
+    :undoc-members:
+
+.. automodule:: CPAC.utils.configuration.diff
+    :members:
+    :undoc-members:
+
+.. automodule:: CPAC.utils.configuration.yaml_template
+    :members:
+    :undoc-members:
+
 Create FMRIB's Local Analysis of Mixed Effects (FLAME) Model Files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/_sources/developer/utils.rst
+++ b/docs/_sources/developer/utils.rst
@@ -18,10 +18,6 @@ BIDS Data Configuration
 Configuration
 ^^^^^^^^^^^^^
 
-.. automodule:: CPAC.utils.configuration
-    :members:
-    :undoc-members:
-
 .. automodule:: CPAC.utils.configuration.configuration
     :members:
     :undoc-members:

--- a/docs/_sources/developer/workflows/cpac_pipeline.rst
+++ b/docs/_sources/developer/workflows/cpac_pipeline.rst
@@ -7,7 +7,7 @@ C-PAC Pipeline Construction
 Configuration Object
 ====================
 
-The 'c' variable in cpac_pipeline.py is a `Configuration object <https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/utils/configuration.py>`_, which is an abstract representation used to store the options for the pipeline configuration YAML after it is read in by C-PAC.  Each attribute of the Configuration object is a key from the YAML file, with values mirroring the YAML.
+The 'c' variable in cpac_pipeline.py is a :py:class:`~CPAC.utils.configuration.configuration.Configuration` object, which is an abstract representation used to store the options for the pipeline configuration YAML after it is read in by C-PAC.  Each attribute of the Configuration object is a key from the YAML file, with values mirroring the YAML.
 
 Strategy Object
 ===============

--- a/docs/_sources/user/pipelines/pipeline_config.rst
+++ b/docs/_sources/user/pipelines/pipeline_config.rst
@@ -51,7 +51,10 @@ If you want to base a pipeline on another pipeline configuration YAML file, you 
 
    FROM: /path/to/pipeline.yml
 
-in your pipeline configuration file. You can use the name of a :doc:`preconfigured pipeline </user/pipelines/preconfig>` instead of a filepath if you want to base a configuration file on a preconfigured pipeline. If ``FROM`` is not specified, the pipeline will be based on :doc:`the default pipeline </user/pipelines/default>`.
+in your pipeline configuration file. You can use the name of a :doc:`preconfigured pipeline </user/pipelines/preconfig>` instead of a filepath if you want to base a configuration file on a preconfigured pipeline. If ``FROM`` is not specified, the pipeline will be based on :doc:`the blank pipeline </user/pipelines/blank>`.
+
+.. versionchanged:: 1.8.5
+   From version 1.8.0 to version 1.8.5, unspecified keys were based on the default configuration rather than the blank preconfiguration.
 
 C-PAC will include all expected keys from the pipeline file specified in ``FROM`` (or the default pipeline if none is specified). Any keys specified in a pipeline configuration file will take precedence over the same key in the ``FROM`` base configuration, but all omitted keys will retain their values from the ``FROM`` base configuration.
 
@@ -59,7 +62,7 @@ From terminal, you can quickly generate a default pipeline configuration YAML fi
 
    cpac utils pipe-config new-template
 
-You can then edit the file as needed. For values that you want to leave at the default, you can either leave the key as-is, or you can remove the key, and C-PAC will automatically use value from the default pipeline configuration (or from the pipeline specified in ``FROM``).
+You can then edit the file as needed. For values that you want to leave at the default, you can either leave the key as-is, or you can add the line ``FROM: default``, remove the key, and C-PAC will automatically use value from the default pipeline configuration (or from the pipeline specified in ``FROM``).
 
 If you want to run the analysis from terminal::
 

--- a/docs/_sources/user/pipelines/preconfig.rst
+++ b/docs/_sources/user/pipelines/preconfig.rst
@@ -7,7 +7,7 @@ human
 default: The Default Pipeline
 -----------------------------
 
-:doc:`Pipeline Configuration YAML </references/default_pipeline.yml>`
+:doc:`Pipeline Configuration YAML </user/pipelines/default>`
 
 .. note::
    
@@ -54,7 +54,7 @@ References
 abcd-options
 ------------
 
-:doc:`Pipeline Configuration YAML </references/abcd-options_pipeline.yml>`
+:doc:`Pipeline Configuration YAML </user/pipelines/abcd-options>`
 
 .. warning::
 
@@ -63,7 +63,7 @@ abcd-options
 anat-only: Default with Anatomical Preprocessing Only
 -----------------------------------------------------
 
-:doc:`Pipeline Configuration YAML </references/anat-only_pipeline.yml>`
+:doc:`Pipeline Configuration YAML </user/pipelines/anat-only>`
 
 Based on the preprocessing decisions of the default pipeline, this preconfiguration allows you to immediately kick off a run with only anatomical preprocessing selected. This includes:
 
@@ -74,7 +74,7 @@ Based on the preprocessing decisions of the default pipeline, this preconfigurat
 preproc: Default without Derivatives
 ------------------------------------
 
-:doc:`Pipeline Configuration YAML </references/preproc_pipeline.yml>`
+:doc:`Pipeline Configuration YAML </user/pipelines/preproc>`
 
 Based on the preprocessing decisions of the default pipeline, this preconfiguration allows you to preprocess all of your data, without launching into calculation of outputs and data derivatives. This includes:
 
@@ -95,7 +95,7 @@ Functional:
 fmriprep-options: fMRIPrep options Pipeline
 -------------------------------------------
 
-:doc:`Pipeline Configuration YAML </references/fmriprep-options_pipeline.yml>`
+:doc:`Pipeline Configuration YAML </user/pipelines/fmriprep-options>`
 
 This pipeline is designed to increase reproducibility with the preprocessing results of the fmriprep pipeline package\ :footcite:`fMRI16` produced by the `Poldrack Lab at Stanford University <https://poldracklab.stanford.edu/>`_.
 
@@ -113,7 +113,7 @@ References
 ndmg: Neurodata's 'ndmg-f' Pipeline
 -----------------------------------
 
-:doc:`Pipeline Configuration YAML </references/ndmg_pipeline.yml>`
+:doc:`Pipeline Configuration YAML </user/pipelines/ndmg>`
 
 This pipeline is the result of `Neurodata's <https://neurodata.io/>`_ study to converge upon the intersection of pipeline configuration decisions that maximizes discriminability between participants' data, drawing from the connectome graphs produced (labeled 'ndmg_graph' in the C-PAC output directory). This pipeline invokes a minimal set of preprocessing.
 
@@ -133,7 +133,7 @@ References
 rbc-options: ReproBrainChart Options Pipeline
 ---------------------------------------------
 
-:doc:`Pipeline Configuration YAML </references/rbc-options_pipeline.yml>`
+:doc:`Pipeline Configuration YAML </user/pipelines/rbc-options>`
 
 RBC-options pipeline was built and integrated in C-PAC based on the Reproducible Brain Charts initiative, which aims to aggregate and harmonize phenotypic and neuroimage data to delineate node mechanisms regarding developmental basis of psychopathology in youth and yield reproducible growth charts of brain development\ :footcite:`Hoff21`.
 
@@ -148,7 +148,7 @@ non-human primate
 monkey: Default with Monkey Preprocessing 
 -----------------------------------------
 
-:doc:`Pipeline Configuration YAML </references/monkey_pipeline.yml>`
+:doc:`Pipeline Configuration YAML </user/pipelines/monkey>`
 
 This pipeline is based on the work of Xu et al.\ :footcite:`Xu19` and nhp-ABCD-BIDS-pipeline.\ :footcite:`Stur20`
 
@@ -190,14 +190,14 @@ testing
 benchmark-ANTS: C-PAC Benchmark with ANTs Registration
 ------------------------------------------------------
 
-:doc:`Pipeline Configuration YAML </references/benchmark-ANTS_pipeline.yml>`
+:doc:`Pipeline Configuration YAML </user/pipelines/benchmark-ANTS>`
 
 The benchmark pipeline has remained mostly unchanged since the project's inception, and is used at the end of each release cycle to ensure the results of C-PAC's key outputs have not changed. It is designed to test a wide range of pipeline options. This pipeline is based on registration-to-template using the ANTs/ITK toolset, as this decision impacts many other aspects of the pipeline further downstream.
 
 benchmark-FNIRT: C-PAC Benchmark with FSL FNIRT Registration
 ------------------------------------------------------------
 
-:doc:`Pipeline Configuration YAML </references/benchmark-FNIRT_pipeline.yml>`
+:doc:`Pipeline Configuration YAML </user/pipelines/benchmark-FNIRT>`
 
 The benchmark pipeline has remained mostly unchanged since the project's inception, and is used at the end of each release cycle to ensure the results of C-PAC's key outputs have not changed. It is designed to test a wide range of pipeline options. This pipeline is based on registration-to-template using the FSL FLIRT & FNIRT, as this decision impacts many other aspects of the pipeline further downstream.
 

--- a/docs/_sources/user/pipelines/preconfig.rst
+++ b/docs/_sources/user/pipelines/preconfig.rst
@@ -7,7 +7,7 @@ human
 default: The Default Pipeline
 -----------------------------
 
-Pipeline Configuration YAML: `https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/resources/configs/pipeline_config_default.yml <https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/resources/configs/pipeline_config_default.yml>`_
+:doc:`Pipeline Configuration YAML </references/default_pipeline.yml>`
 
 .. note::
    
@@ -54,6 +54,8 @@ References
 abcd-options
 ------------
 
+:doc:`Pipeline Configuration YAML </references/abcd-options_pipeline.yml>`
+
 .. warning::
 
    :doc:`/user/known-issues/FCP-INDI/C-PAC/2104`
@@ -61,7 +63,7 @@ abcd-options
 anat-only: Default with Anatomical Preprocessing Only
 -----------------------------------------------------
 
-Pipeline Configuration YAML: `https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/resources/configs/pipeline_config_anat-only.yml <https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/resources/configs/pipeline_config_anat-only.yml>`_
+:doc:`Pipeline Configuration YAML </references/anat-only_pipeline.yml>`
 
 Based on the preprocessing decisions of the default pipeline, this preconfiguration allows you to immediately kick off a run with only anatomical preprocessing selected. This includes:
 
@@ -72,7 +74,7 @@ Based on the preprocessing decisions of the default pipeline, this preconfigurat
 preproc: Default without Derivatives
 ------------------------------------
 
-Pipeline Configuration YAML: `https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/resources/configs/pipeline_config_preproc.yml <https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/resources/configs/pipeline_config_preproc.yml>`_
+:doc:`Pipeline Configuration YAML </references/preproc_pipeline.yml>`
 
 Based on the preprocessing decisions of the default pipeline, this preconfiguration allows you to preprocess all of your data, without launching into calculation of outputs and data derivatives. This includes:
 
@@ -90,10 +92,10 @@ Functional:
 * Nuisance correction & filtering
 * Registration to template (via ANTs/ITK)
 
-fmriprep-options: fmriprep-Options Pipeline
+fmriprep-options: fMRIPrep options Pipeline
 -------------------------------------------
 
-Pipeline Configuration YAML: `https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/resources/configs/pipeline_config_fmriprep-options.yml <https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/resources/configs/pipeline_config_fmriprep-options.yml>`_
+:doc:`Pipeline Configuration YAML </references/fmriprep-options_pipeline.yml>`
 
 This pipeline is designed to increase reproducibility with the preprocessing results of the fmriprep pipeline package\ :footcite:`fMRI16` produced by the `Poldrack Lab at Stanford University <https://poldracklab.stanford.edu/>`_.
 
@@ -111,7 +113,7 @@ References
 ndmg: Neurodata's 'ndmg-f' Pipeline
 -----------------------------------
 
-Pipeline Configuration YAML: `https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/resources/configs/pipeline_config_ndmg.yml <https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/resources/configs/pipeline_config_ndmg.yml>`_
+:doc:`Pipeline Configuration YAML </references/ndmg_pipeline.yml>`
 
 This pipeline is the result of `Neurodata's <https://neurodata.io/>`_ study to converge upon the intersection of pipeline configuration decisions that maximizes discriminability between participants' data, drawing from the connectome graphs produced (labeled 'ndmg_graph' in the C-PAC output directory). This pipeline invokes a minimal set of preprocessing.
 
@@ -131,7 +133,7 @@ References
 rbc-options: ReproBrainChart Options Pipeline
 ---------------------------------------------
 
-Pipeline Configuration YAML: `https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/resources/configs/pipeline_config_rbc-options.yml <https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/resources/configs/pipeline_config_rbc-options.yml>`_
+:doc:`Pipeline Configuration YAML </references/rbc-options_pipeline.yml>`
 
 RBC-options pipeline was built and integrated in C-PAC based on the Reproducible Brain Charts initiative, which aims to aggregate and harmonize phenotypic and neuroimage data to delineate node mechanisms regarding developmental basis of psychopathology in youth and yield reproducible growth charts of brain development\ :footcite:`Hoff21`.
 
@@ -146,7 +148,7 @@ non-human primate
 monkey: Default with Monkey Preprocessing 
 -----------------------------------------
 
-Pipeline Configuration YAML: `https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/resources/configs/pipeline_config_monkey.yml <https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/resources/configs/pipeline_config_monkey.yml>`_
+:doc:`Pipeline Configuration YAML </references/monkey_pipeline.yml>`
 
 This pipeline is based on the work of Xu et al.\ :footcite:`Xu19` and nhp-ABCD-BIDS-pipeline.\ :footcite:`Stur20`
 
@@ -188,14 +190,14 @@ testing
 benchmark-ANTS: C-PAC Benchmark with ANTs Registration
 ------------------------------------------------------
 
-Pipeline Configuration YAML: `https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/resources/configs/pipeline_config_benchmark-ANTS.yml <https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/resources/configs/pipeline_config_benchmark-ANTS.yml>`_
+:doc:`Pipeline Configuration YAML </references/benchmark-ANTS_pipeline.yml>`
 
 The benchmark pipeline has remained mostly unchanged since the project's inception, and is used at the end of each release cycle to ensure the results of C-PAC's key outputs have not changed. It is designed to test a wide range of pipeline options. This pipeline is based on registration-to-template using the ANTs/ITK toolset, as this decision impacts many other aspects of the pipeline further downstream.
 
 benchmark-FNIRT: C-PAC Benchmark with FSL FNIRT Registration
 ------------------------------------------------------------
 
-Pipeline Configuration YAML: `https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/resources/configs/pipeline_config_benchmark-FNIRT.yml <https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/resources/configs/pipeline_config_benchmark-FNIRT.yml>`_
+:doc:`Pipeline Configuration YAML </references/benchmark-FNIRT_pipeline.yml>`
 
 The benchmark pipeline has remained mostly unchanged since the project's inception, and is used at the end of each release cycle to ensure the results of C-PAC's key outputs have not changed. It is designed to test a wide range of pipeline options. This pipeline is based on registration-to-template using the FSL FLIRT & FNIRT, as this decision impacts many other aspects of the pipeline further downstream.
 


### PR DESCRIPTION
## Related to
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Related to FCP-INDI/C-PAC#2148 by @shnizzedy 

Related to <details><summary>https://github.com/FCP-INDI/C-PAC/issues/2145#issuecomment-2323253398 by @suxpert</summary>

> I regard the config file as `terrified` since it:
> […]
> - was too complex since there are too many things to write, but I did not find the logic of all those stuffs;

</details>

Related to <details><summary>https://github.com/FCP-INDI/C-PAC/issues/2145#issuecomment-2327403236 by @tamsinrogers</summary>

> If FROM is not specified, the pipeline will be based on [the blank pipeline](https://github.com/FCP-INDI/C-PAC/blob/v1.8.7/CPAC/resources/configs/pipeline_config_blank.yml).

</details>

Related to <details><summary>FCP-INDI/C-PAC#1801 by @shnizzedy</summary>

> * Updates the base for minified configs from default to blank.

</details>

## Description
<!-- Concisely describe what the pull request does. -->

* Updates
  > If `FROM` is not specified, the pipeline will be based on [the default pipeline](https://fcp-indi.github.io/docs/nightly/user/pipelines/default).
  
  to
  > If `FROM` is not specified, the pipeline will be based on [the blank pipeline](https://fcp-indi.github.io/docs/nightly/user/pipelines/blank).
* Autogenerates pages like https://fcp-indi.github.io/docs/v1.8.7/user/pipelines/default for syntax-highlighted displays of all the preconfigs from within the documentation site.
* Updates the "Pipeline Configuration YAML" links in https://fcp-indi.github.io/docs/v1.8.7/user/pipelines/preconfig to point to those autogenerated pages.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

### changes
| before this PR | with this PR |
|---|---|
|!["If FROM is not specified, the pipeline will be based on the default pipeline."](https://github.com/user-attachments/assets/df05484a-bb9a-4676-8fa7-2a56e1be2ec3)|!["If FROM is not specified, the pipeline will be based on the blank pipeline."](https://github.com/user-attachments/assets/97cad309-53cd-4f9e-8b79-024f66237326)|
|!["Pipeline Configuration YAML: https://github.com/FCP-INDI/C-PAC/blob/v1.8.7/CPAC/resources/configs/pipeline_config_default.yml"](https://github.com/user-attachments/assets/70ae8dd8-26c1-43a9-b161-ab25705e7931)<br/>(link to https://github.com/FCP-INDI/C-PAC/blob/v1.8.7/CPAC/resources/configs/pipeline_config_default.yml)|![Pipeline Configuration YAML](https://github.com/user-attachments/assets/566a4c1a-42b2-4a01-8899-60618e0e950c)<br/>(link to https://fcp-indi.github.io/docs/v1.8.7/user/pipelines/default)|

### additions
<details><summary>Each preconfig automatically gets a page like this one for the blank preconfig:</summary>

![top part of blank preconfig documentation](https://github.com/user-attachments/assets/5903fb49-10e1-45c8-bb5d-ca5a8f01f73a)
![bottom part of blank preconfig documentation](https://github.com/user-attachments/assets/06ec8026-d4a6-4c82-a30a-37cff7fc345a)
</details>

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).  <!-- If you want to in include a leading emoji, check out https://gitmoji.dev for a pseudo-standard set of options -->
- [x] My pull request targets the `source` branch of the repository. <!-- Change this branch if you're targeting a branch other than `source` -->
- [x] My commit messages follow best practices.
- [x] My code follows the [established code style of the repository](../CONTRIBUTING.md).
- [x] I tried [letting the CI build this branch on a fork or built the project locally](../CONTRIBUTING.md#building) and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
