### PR TITLE
📝 Document FCP-INDI/C-PAC#2152 + FCP-INDI/C-PAC#2153

### DIFF
--- a/docs/_sources/conf.py
+++ b/docs/_sources/conf.py
@@ -585,6 +585,8 @@ texinfo_documents = [
 
 rst_prolog = """
 
+.. |see 1.8.5 rnotes| replace:: See :doc:`/user/release_notes/v1.8.5` for details.
+
 .. |version as code| replace:: ``{version}``
 
 """.format(

--- a/docs/_sources/user/help.rst
+++ b/docs/_sources/user/help.rst
@@ -85,3 +85,10 @@ Recently Resolved Common Issues
 -------------------------------------
 
 .. include:: /user/known-issues/FCP-INDI/C-PAC/2110.rst
+
+First two TRs not affected by bandpass filter
+---------------------------------------------
+
+.. include:: /user/known-issues/FCP-INDI/C-PAC/2152.rst
+
+

--- a/docs/_sources/user/known-issues/FCP-INDI/C-PAC/2152.rst
+++ b/docs/_sources/user/known-issues/FCP-INDI/C-PAC/2152.rst
@@ -1,0 +1,28 @@
+..
+   The headings here start with * to nest under - in user/help
+
+🐛 First two TRs not affected by bandpass filter
+************************************************
+
+.. versionadded:: 1.8.6
+
+.. versionremoved:: 1.8.8
+
+Issue :issue:`2152` resolved in :issue:`2153`
+
+When running C-PAC v1.8.6 or v1.8.7 with a bandpass filter, the ``1D`` file is treated as if the header is 5 rows regardless of how many rows are in the actual header (typically 3 rows).
+
+This bug originated in v1.8.6 and was resolved in v1.8.8.
+
+Workarounds
+###########
+
+Preferred
+`````````
+
+Use an unaffected version of C-PAC if using bandpass filters.
+
+Alternative
+```````````
+
+If you're using an affected version of C-PAC, you can make sure the 1D files have 5-row headers. This may require deleting some downstream working files and outputs and rerunning after modifying the intermediate ``1D`` file(s).

--- a/docs/_sources/user/nuisance.rst
+++ b/docs/_sources/user/nuisance.rst
@@ -127,6 +127,10 @@ Configuring Temporal Filtering Options
 
 #. **Select regressors: - [dialogue: Low-frequency cutoff, High-frequency cutoff]:**  Clicking on the *+* icon to the right of the box here will bring up a dialog where you can define the upper and lower cutoffs for the bandpass filter.  You may generate multiple sets of bandpass filter strategies in this way.  When you are done defining bandpasses, check the box next to each bandpass you would like to run.
 
+.. warning::
+
+   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
+
 .. _nuisance-no-gui:
 
 .. include:: /user/pipelines/without_gui.rst
@@ -186,6 +190,10 @@ C-PAC is now compatible with fMRIPrep output directories so that users can run n
 * If there are regressor strategies under :ref:`nuisance_corrections > 2-nuisance_regression > Regressors`, the 'Name' field of one strategy must match the name of the regressor strategy listed under :ref:`ingress_regressors`. If you are not running bandpass filtering, the field :ref:`nuisance_corrections > 2-nuisance_regression > Regressors` can be blank. See below for an example.
 
 * Nuisance regression cannot fork with ingressed regressors
+
+.. warning::
+
+   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
 
 .. code-block:: yaml
  

--- a/docs/_sources/user/pipelines/desc/default.rst
+++ b/docs/_sources/user/pipelines/desc/default.rst
@@ -1,0 +1,45 @@
+C-PAC is packaged with a default processing pipeline so that you can get your data preprocessing and analysis started immediately. Just pull the C-PAC Docker container and kick off the container with your data, and you're on your way.
+
+The default processing pipeline performs fMRI processing using four strategies, with and without global signal regression, with and without bandpass filtering.
+
+.. warning::
+
+   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
+
+Anatomical processing begins with conforming the data to RPI orientation and removing orientation header information that will interfere with further processing. A non-linear transform between skull-on images and a 2mm MNI brain-only template are calculated using ANTs\ :footcite:`Avan08`. 
+
+.. versionchanged:: 1.8.5
+
+   Images are them skull-stripped using FSL's BET\ :footcite:`Smit02` (was using AFNI's 3dSkullStrip\ :footcite:`Cox96,Cox97` prior to v1.8.5. |see 1.8.5 rnotes|) and subsequently segmented into WM, GM, and CSF using FSL's FAST tool\ :footcite:`Zhan01`.
+
+The resulting WM mask was multiplied by a WM prior map that was transformed into individual space using the inverse of the linear transforms previously calculated during the ANTs procedure. A CSF mask was multiplied by a ventricle map derived from the Harvard-Oxford atlas distributed with FSL\ :footcite:`Smit04`. Skull-stripped images and grey matter tissue maps are written into MNI space at 2mm resolution.
+
+Functional preprocessing begins with resampling the data to RPI orientation, and slice timing correction. Next, motion correction is performed using a two-stage approach in which the images are first coregistered to the mean fMRI and then a new mean is calculated and used as the target for a second coregistration (AFNI 3dvolreg\ :footcite:`Cox99`). A 7 degree of freedom linear transform between the mean fMRI and the structural image is calculated using FSL's implementation of boundary-based registration\ :footcite:`Zhan01`. Nuisance variable regression (NVR) is performed on motion corrected data using a 2nd order polynomial, a 24-regressor model of motion\ :footcite:`Fris96`, 5 nuisance signals, identified via principal components analysis of signals obtained from white matter (CompCor\ :footcite:`Behz07`), and mean CSF signal. WM and CSF signals were extracted using the previously described masks after transforming the fMRI data to match them in 2mm space using the inverse of the linear fMRI-sMRI transform. The NVR procedure is performed twice, with and without the inclusion of the global signal as a nuisance regressor. The residuals of the NVR procedure are processed with and without bandpass filtering (0.01Hz < f < 0.1Hz), written into MNI space at 3mm resolution and subsequently smoothed using a 6mm FWHM kernel.
+
+.. warning::
+
+   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
+
+Several different individual level analysis are performed on the fMRI data including:
+
+* **Amplitude of low frequency fluctuations (alff)**\ :footcite:`Zang07`: the variance of each voxel is calculated after bandpass filtering in original space and subsequently written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel.
+.. warning::
+
+   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
+* **Fractional amplitude of low frequency fluctuations (falff)**\ :footcite:`Zou08`: Similar to alff except that the variance of the bandpassed signal is divided by the total variance (variance of non-bandpassed signal).
+.. warning::
+
+   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
+* **Regional homogeneity (ReHo)**\ :footcite:`Zang04`: a simultaneous Kendall rank correlation is calculated between each voxel's time course and the time courses of the 27 voxels that are face, edge, and corner touching the voxel. ReHo is calculated in original space and subsequently written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel.
+* **Voxel mirrored homotopic connectivity (VMHC)**\ :footcite:`Star08`: an non-linear transform is calculated between the skull-on anatomical data and a symmetric brain template in 2mm space. Using this transform, processed fMRI data are written in to symmetric MNI space at 2mm and the correlation between each voxel and its analog in the contralateral hemisphere is calculated. The Fisher transform is applied to the resulting values, which are then spatially smoothed using a 6mm FWHM kernel.
+* **Weighted and binarized degree centrality (DC)**\ :footcite:`Buck09`: fMRI data is written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel. The voxel x voxel similarity matrix is calculated by the correlation between every pair of voxel time courses and then thresholded so that only the top 5% of correlations remain. For each voxel, binarized DC is the number of connections that remain for the voxel after thresholding and weighted DC is the average correlation coefficient across the remaining connections.
+* **Eigenvector centrality (EC)**\ :footcite:`Lohm10`: fMRI data is written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel. The voxel x voxel similarity matrix is calculated by the correlation between every pair of voxel time courses and then thresholded so that only the top 5% of correlations remain. Weighted EC is calculated from the eigenvector corresponding to the largest eigenvalue from an eigenvector decomposition of the resulting similarity. Binarized EC is the first eigenvector of the similarity matrix after setting the non-zero values in the resulting matrix are set to 1.
+* **Local functional connectivity density (lFCD)**\ :footcite:`Toma10`: fMRI data is written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel. For each voxel, lFCD corresponds to the number of contiguous voxels that are correlated with the voxel above 0.6 (r>0.6). This is similar to degree centrality, except it only includes the voxels that are directly connected to the seed voxel.
+* **10 intrinsic connectivity networks (ICNs) from dual regression**\ :footcite:`Beck09`: a template including 10 ICNs from a meta-analysis of resting state and task fMRI data\ :footcite:`Smit09` is spatially regressed against the processed fMRI data in MNI space. The resulting time courses are entered into a multiple regression with the voxel data in original space to calculate individual representations of the 10 ICNs. The resulting networks are written into MNI space at 2mm and then spatially smoothed using a 6mm FWHM kernel.
+* **Seed correlation analysis (SCA)**: preprocessed fMRI data is to match template that includes 160 regions of interest defined from a meta-analysis of different task results\ :footcite:`Dose10`. A time series is calculated for each region from the mean of all intra-ROI voxel time series. A separate functional connectivity map is calculated per ROI by correlating its time course with the time courses of every other voxel in the brain. Resulting values are Fisher transformed, written into MNI space at 2mm resolution, and then spatially smoothed using a 6mm FWHM kernel.
+* **Time series extraction**: similar the procedure used for time series analysis, the preprocessed functional data is written into MNI space at 2mm and then time series for the various atlases are extracted by averaging within region voxel time courses. This procedure was used to generate summary time series for the automated anatomic labelling atlas\ :footcite:`Tzou02`, Eickhoff-Zilles atlas\ :footcite:`Eick05`, Harvard-Oxford atlas\ :footcite:`Harv`, Talaraich and Tournoux atlas\ :footcite:`Lanc00`, 200 and 400 regions from the spatially constrained clustering voxel timeseries\ :footcite:`Crad12`, and 160 ROIs from a meta-analysis of task results\ :footcite:`Dose10`. Time series for 10 ICNs were extracted using spatial regression.
+
+References
+**********
+
+.. footbibliography::

--- a/docs/_sources/user/pipelines/preconfig.rst
+++ b/docs/_sources/user/pipelines/preconfig.rst
@@ -19,51 +19,7 @@ Pipeline Configuration YAML: `https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/r
 
       This pipeline was modified during the v1.8.5 release cycle. |see 1.8.5 rnotes| The previous default pipeline has been preserved as |default-deprecated|_
 
-C-PAC is packaged with a default processing pipeline so that you can get your data preprocessing and analysis started immediately. Just pull the C-PAC Docker container and kick off the container with your data, and you're on your way.
-
-The default processing pipeline performs fMRI processing using four strategies, with and without global signal regression, with and without bandpass filtering.
-
-.. warning::
-
-   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
-
-Anatomical processing begins with conforming the data to RPI orientation and removing orientation header information that will interfere with further processing. A non-linear transform between skull-on images and a 2mm MNI brain-only template are calculated using ANTs\ :footcite:`Avan08`. 
-
-.. versionchanged:: 1.8.5
-
-   Images are them skull-stripped using FSL's BET\ :footcite:`Smit02` (was using AFNI's 3dSkullStrip\ :footcite:`Cox96,cite-default-Cox97` prior to v1.8.5. |see 1.8.5 rnotes|) and subsequently segmented into WM, GM, and CSF using FSL's FAST tool\ :footcite:`Zhan01`.
-
-The resulting WM mask was multiplied by a WM prior map that was transformed into individual space using the inverse of the linear transforms previously calculated during the ANTs procedure. A CSF mask was multiplied by a ventricle map derived from the Harvard-Oxford atlas distributed with FSL\ :footcite:`Smit04`. Skull-stripped images and grey matter tissue maps are written into MNI space at 2mm resolution.
-
-Functional preprocessing begins with resampling the data to RPI orientation, and slice timing correction. Next, motion correction is performed using a two-stage approach in which the images are first coregistered to the mean fMRI and then a new mean is calculated and used as the target for a second coregistration (AFNI 3dvolreg\ :footcite:`Cox99`). A 7 degree of freedom linear transform between the mean fMRI and the structural image is calculated using FSL's implementation of boundary-based registration\ :footcite:`Zhan01`. Nuisance variable regression (NVR) is performed on motion corrected data using a 2nd order polynomial, a 24-regressor model of motion\ :footcite:`Fris96`, 5 nuisance signals, identified via principal components analysis of signals obtained from white matter (CompCor\ :footcite:`Behz07`), and mean CSF signal. WM and CSF signals were extracted using the previously described masks after transforming the fMRI data to match them in 2mm space using the inverse of the linear fMRI-sMRI transform. The NVR procedure is performed twice, with and without the inclusion of the global signal as a nuisance regressor. The residuals of the NVR procedure are processed with and without bandpass filtering (0.01Hz < f < 0.1Hz), written into MNI space at 3mm resolution and subsequently smoothed using a 6mm FWHM kernel.
-
-.. warning::
-
-   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
-
-Several different individual level analysis are performed on the fMRI data including:
-
-* **Amplitude of low frequency fluctuations (alff)**\ :footcite:`Zang07`: the variance of each voxel is calculated after bandpass filtering in original space and subsequently written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel.
-.. warning::
-
-   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
-* **Fractional amplitude of low frequency fluctuations (falff)**\ :footcite:`Zou08`: Similar to alff except that the variance of the bandpassed signal is divided by the total variance (variance of non-bandpassed signal).
-.. warning::
-
-   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
-* **Regional homogeneity (ReHo)**\ :footcite:`Zang04`: a simultaneous Kendall rank correlation is calculated between each voxel's time course and the time courses of the 27 voxels that are face, edge, and corner touching the voxel. ReHo is calculated in original space and subsequently written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel.
-* **Voxel mirrored homotopic connectivity (VMHC)**\ :footcite:`Star08`: an non-linear transform is calculated between the skull-on anatomical data and a symmetric brain template in 2mm space. Using this transform, processed fMRI data are written in to symmetric MNI space at 2mm and the correlation between each voxel and its analog in the contralateral hemisphere is calculated. The Fisher transform is applied to the resulting values, which are then spatially smoothed using a 6mm FWHM kernel.
-* **Weighted and binarized degree centrality (DC)**\ :footcite:`Buck09`: fMRI data is written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel. The voxel x voxel similarity matrix is calculated by the correlation between every pair of voxel time courses and then thresholded so that only the top 5% of correlations remain. For each voxel, binarized DC is the number of connections that remain for the voxel after thresholding and weighted DC is the average correlation coefficient across the remaining connections.
-* **Eigenvector centrality (EC)**\ :footcite:`Lohm10`: fMRI data is written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel. The voxel x voxel similarity matrix is calculated by the correlation between every pair of voxel time courses and then thresholded so that only the top 5% of correlations remain. Weighted EC is calculated from the eigenvector corresponding to the largest eigenvalue from an eigenvector decomposition of the resulting similarity. Binarized EC is the first eigenvector of the similarity matrix after setting the non-zero values in the resulting matrix are set to 1.
-* **Local functional connectivity density (lFCD)**\ :footcite:`Toma10`: fMRI data is written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel. For each voxel, lFCD corresponds to the number of contiguous voxels that are correlated with the voxel above 0.6 (r>0.6). This is similar to degree centrality, except it only includes the voxels that are directly connected to the seed voxel.
-* **10 intrinsic connectivity networks (ICNs) from dual regression**\ :footcite:`Beck09`: a template including 10 ICNs from a meta-analysis of resting state and task fMRI data\ :footcite:`Smit09` is spatially regressed against the processed fMRI data in MNI space. The resulting time courses are entered into a multiple regression with the voxel data in original space to calculate individual representations of the 10 ICNs. The resulting networks are written into MNI space at 2mm and then spatially smoothed using a 6mm FWHM kernel.
-* **Seed correlation analysis (SCA)**: preprocessed fMRI data is to match template that includes 160 regions of interest defined from a meta-analysis of different task results\ :footcite:`Dose10`. A time series is calculated for each region from the mean of all intra-ROI voxel time series. A separate functional connectivity map is calculated per ROI by correlating its time course with the time courses of every other voxel in the brain. Resulting values are Fisher transformed, written into MNI space at 2mm resolution, and then spatially smoothed using a 6mm FWHM kernel.
-* **Time series extraction**: similar the procedure used for time series analysis, the preprocessed functional data is written into MNI space at 2mm and then time series for the various atlases are extracted by averaging within region voxel time courses. This procedure was used to generate summary time series for the automated anatomic labelling atlas\ :footcite:`Tzou02`, Eickhoff-Zilles atlas\ :footcite:`Eick05`, Harvard-Oxford atlas\ :footcite:`Harv`, Talaraich and Tournoux atlas\ :footcite:`Lanc00`, 200 and 400 regions from the spatially constrained clustering voxel timeseries\ :footcite:`Crad12`, and 160 ROIs from a meta-analysis of task results\ :footcite:`Dose10`. Time series for 10 ICNs were extracted using spatial regression.
-
-References
-**********
-
-.. footbibliography::
+.. include:: /user/pipelines/desc/default.rst
 
 abcd-options
 ------------
@@ -216,5 +172,3 @@ The benchmark pipeline has remained mostly unchanged since the project's incepti
 .. |default-deprecated| replace:: ``default-deprecated``
 
 .. _default-deprecated: https://github.com/FCP-INDI/C-PAC/blob/main/CPAC/resources/configs/pipeline_config_default-deprecated.yml
-
-.. |see 1.8.5 rnotes| replace:: See :doc:`/user/release_notes/v1.8.5` for details.

--- a/docs/_sources/user/pipelines/preconfig.rst
+++ b/docs/_sources/user/pipelines/preconfig.rst
@@ -23,6 +23,10 @@ C-PAC is packaged with a default processing pipeline so that you can get your da
 
 The default processing pipeline performs fMRI processing using four strategies, with and without global signal regression, with and without bandpass filtering.
 
+.. warning::
+
+   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
+
 Anatomical processing begins with conforming the data to RPI orientation and removing orientation header information that will interfere with further processing. A non-linear transform between skull-on images and a 2mm MNI brain-only template are calculated using ANTs\ :footcite:`Avan08`. 
 
 .. versionchanged:: 1.8.5
@@ -33,10 +37,20 @@ The resulting WM mask was multiplied by a WM prior map that was transformed into
 
 Functional preprocessing begins with resampling the data to RPI orientation, and slice timing correction. Next, motion correction is performed using a two-stage approach in which the images are first coregistered to the mean fMRI and then a new mean is calculated and used as the target for a second coregistration (AFNI 3dvolreg\ :footcite:`Cox99`). A 7 degree of freedom linear transform between the mean fMRI and the structural image is calculated using FSL's implementation of boundary-based registration\ :footcite:`Zhan01`. Nuisance variable regression (NVR) is performed on motion corrected data using a 2nd order polynomial, a 24-regressor model of motion\ :footcite:`Fris96`, 5 nuisance signals, identified via principal components analysis of signals obtained from white matter (CompCor\ :footcite:`Behz07`), and mean CSF signal. WM and CSF signals were extracted using the previously described masks after transforming the fMRI data to match them in 2mm space using the inverse of the linear fMRI-sMRI transform. The NVR procedure is performed twice, with and without the inclusion of the global signal as a nuisance regressor. The residuals of the NVR procedure are processed with and without bandpass filtering (0.01Hz < f < 0.1Hz), written into MNI space at 3mm resolution and subsequently smoothed using a 6mm FWHM kernel.
 
+.. warning::
+
+   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
+
 Several different individual level analysis are performed on the fMRI data including:
 
 * **Amplitude of low frequency fluctuations (alff)**\ :footcite:`Zang07`: the variance of each voxel is calculated after bandpass filtering in original space and subsequently written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel.
+.. warning::
+
+   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
 * **Fractional amplitude of low frequency fluctuations (falff)**\ :footcite:`Zou08`: Similar to alff except that the variance of the bandpassed signal is divided by the total variance (variance of non-bandpassed signal).
+.. warning::
+
+   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
 * **Regional homogeneity (ReHo)**\ :footcite:`Zang04`: a simultaneous Kendall rank correlation is calculated between each voxel's time course and the time courses of the 27 voxels that are face, edge, and corner touching the voxel. ReHo is calculated in original space and subsequently written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel.
 * **Voxel mirrored homotopic connectivity (VMHC)**\ :footcite:`Star08`: an non-linear transform is calculated between the skull-on anatomical data and a symmetric brain template in 2mm space. Using this transform, processed fMRI data are written in to symmetric MNI space at 2mm and the correlation between each voxel and its analog in the contralateral hemisphere is calculated. The Fisher transform is applied to the resulting values, which are then spatially smoothed using a 6mm FWHM kernel.
 * **Weighted and binarized degree centrality (DC)**\ :footcite:`Buck09`: fMRI data is written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel. The voxel x voxel similarity matrix is calculated by the correlation between every pair of voxel time courses and then thresholded so that only the top 5% of correlations remain. For each voxel, binarized DC is the number of connections that remain for the voxel after thresholding and weighted DC is the average correlation coefficient across the remaining connections.

--- a/docs/_sources/user/quick.rst
+++ b/docs/_sources/user/quick.rst
@@ -14,37 +14,7 @@ For instructions to run C-PAC in Docker or Singularity without installing cpac (
 Default Pipeline
 ----------------
 
-C-PAC is packaged with a default processing pipeline so that you can get your data preprocessing and analysis started immediately. Just pull the C-PAC Docker container and kick off the container with your data, and you're on your way.
-
-The default processing pipeline performs fMRI processing using four strategies, with and without global signal regression, with and without bandpass filtering.
-
-.. warning::
-
-   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
-
-Anatomical processing begins with conforming the data to RPI orientation and removing orientation header information that will interfere with further processing. A non-linear transform between skull-on images and a 2mm MNI brain-only template are calculated using ANTs [3]. Images are them skull-stripped using AFNI's 3dSkullStrip [5] and subsequently segmented into WM, GM, and CSF using FSL’s fast tool [6]. The resulting WM mask was multiplied by a WM prior map that was transformed into individual space using the inverse of the linear transforms previously calculated during the ANTs procedure. A CSF mask was multiplied by a ventricle map derived from the Harvard-Oxford atlas distributed with FSL [4]. Skull-stripped images and grey matter tissue maps are written into MNI space at 2mm resolution.
-
-Functional preprocessing begins with resampling the data to RPI orientation, and slice timing correction. Next, motion correction is performed using a two-stage approach in which the images are first coregistered to the mean fMRI and then a new mean is calculated and used as the target for a second coregistration (AFNI 3dvolreg [2]). A 7 degree of freedom linear transform between the mean fMRI and the structural image is calculated using FSL’s implementation of boundary-based registration [7]. Nuisance variable regression (NVR) is performed on motion corrected data using a 2nd order polynomial, a 24-regressor model of motion [8], 5 nuisance signals, identified via principal components analysis of signals obtained from white matter (CompCor, [9]), and mean CSF signal. WM and CSF signals were extracted using the previously described masks after transforming the fMRI data to match them in 2mm space using the inverse of the linear fMRI-sMRI transform. The NVR procedure is performed twice, with and without the inclusion of the global signal as a nuisance regressor. The residuals of the NVR procedure are processed with and without bandpass filtering (0.001Hz < f < 0.1Hz), written into MNI space at 3mm resolution and subsequently smoothed using a 6mm FWHM kernel.
-
-.. warning::
-
-   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
-
-Several different individual level analysis are performed on the fMRI data including:
-
-* **Amplitude of low frequency fluctuations (alff) [10]:** the variance of each voxel is calculated after bandpass filtering in original space and subsequently written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel.
-* **Fractional amplitude of low frequency fluctuations (falff) [11]:** Similar to alff except that the variance of the bandpassed signal is divided by the total variance (variance of non-bandpassed signal.
-.. warning::
-
-   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
-* **Regional homogeniety (ReHo) [12]:** a simultaneous Kendalls correlation is calculated between each voxel's time course and the time courses of the 27 voxels that are face, edge, and corner touching the voxel. ReHo is calculated in original space and subsequently written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel.
-* **Voxel mirrored homotopic connectivity (VMHC) [13]:** an non-linear transform is calculated between the skull-on anatomical data and a symmetric brain template in 2mm space. Using this transform, processed fMRI data are written in to symmetric MNI space at 2mm and the correlation between each voxel and its analog in the contralateral hemisphere is calculated. The Fisher transform is applied to the resulting values, which are then spatially smoothed using a 6mm FWHM kernel.
-* **Weighted and binarized degree centrality (DC) [14]:** fMRI data is written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel. The voxel x voxel similarity matrix is calculated by the correlation between every pair of voxel time courses and then thresholded so that only the top 5% of correlations remain. For each voxel, binarized DC is the number of connections that remain for the voxel after thresholding and weighted DC is the average correlation coefficient across the remaining connections.
-* **Eigenvector centrality (EC) [15]:** fMRI data is written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel. The voxel x voxel similarity matrix is calculated by the correlation between every pair of voxel time courses and then thresholded so that only the top 5% of correlations remain. Weighted EC is calculated from the eigenvector corresponding to the largest eigenvalue from an eigenvector decomposition of the resulting similarity. Binarized EC, is the first eigenvector of the similarity matrix after setting the non-zero values in the resulting matrix are set to 1.
-* **Local functional connectivity density (lFCD) [16]:** fMRI data is written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel. For each voxel, lFCD corresponds to the number of contiguous voxels that are correlated with the voxel above 0.6 (r>0.6). This is similar to degree centrality, except only voxels that it only includes the voxels that are directly connected to the seed voxel.
-* **10 intrinsic connectivity networks (ICNs) from dual regression [17]:** a template including 10 ICNs from a meta-analysis of resting state and task fMRI data [18] is spatially regressed against the processed fMRI data in MNI space. The resulting time courses are entered into a multiple regression with the voxel data in original space to calculate individual representations of the 10 ICNs. The resulting networks are written into MNI space at 2mm and then spatially smoothed using a 6mm FWHM kernel.
-* **Seed correlation analysis (SCA):** preprocessed fMRI data is to match template that includes 160 regions of interest defined from a meta-analysis of different task results [19]. A time series is calculated for each region from the mean of all intra-ROI voxel time series. A separate functional connectivity map is calculated per ROI by correlating its time course with the time courses of every other voxel in the brain. Resulting values are Fisher transformed, written into MNI space at 2mm resolution, and then spatial smoothed using a 6mm FWHM kernel.
-* **Time series extraction:** similar the procedure used for time series analysis, the preprocessed functional data is written into MNI space at 2mm and then time series for the various atlases are extracted by averaging within region voxel time courses. This procedure was used to generate summary time series for the automated anatomic labelling atlas [20], Eickhoff-Zilles atlas [21], Harvard-Oxford atlas [22], Talaraich and Tournoux atlas [23], 200 and 400 regions from the spatially constrained clustering voxel timeseries [24], and 160 ROIs from a meta-analysis of task results [19]. Time series for 10 ICNs were extracted using spatial regression.
+.. include:: /user/pipelines/desc/default.rst
 
 Pre-configured Pipelines
 ------------------------

--- a/docs/_sources/user/quick.rst
+++ b/docs/_sources/user/quick.rst
@@ -18,14 +18,25 @@ C-PAC is packaged with a default processing pipeline so that you can get your da
 
 The default processing pipeline performs fMRI processing using four strategies, with and without global signal regression, with and without bandpass filtering.
 
+.. warning::
+
+   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
+
 Anatomical processing begins with conforming the data to RPI orientation and removing orientation header information that will interfere with further processing. A non-linear transform between skull-on images and a 2mm MNI brain-only template are calculated using ANTs [3]. Images are them skull-stripped using AFNI's 3dSkullStrip [5] and subsequently segmented into WM, GM, and CSF using FSL’s fast tool [6]. The resulting WM mask was multiplied by a WM prior map that was transformed into individual space using the inverse of the linear transforms previously calculated during the ANTs procedure. A CSF mask was multiplied by a ventricle map derived from the Harvard-Oxford atlas distributed with FSL [4]. Skull-stripped images and grey matter tissue maps are written into MNI space at 2mm resolution.
 
 Functional preprocessing begins with resampling the data to RPI orientation, and slice timing correction. Next, motion correction is performed using a two-stage approach in which the images are first coregistered to the mean fMRI and then a new mean is calculated and used as the target for a second coregistration (AFNI 3dvolreg [2]). A 7 degree of freedom linear transform between the mean fMRI and the structural image is calculated using FSL’s implementation of boundary-based registration [7]. Nuisance variable regression (NVR) is performed on motion corrected data using a 2nd order polynomial, a 24-regressor model of motion [8], 5 nuisance signals, identified via principal components analysis of signals obtained from white matter (CompCor, [9]), and mean CSF signal. WM and CSF signals were extracted using the previously described masks after transforming the fMRI data to match them in 2mm space using the inverse of the linear fMRI-sMRI transform. The NVR procedure is performed twice, with and without the inclusion of the global signal as a nuisance regressor. The residuals of the NVR procedure are processed with and without bandpass filtering (0.001Hz < f < 0.1Hz), written into MNI space at 3mm resolution and subsequently smoothed using a 6mm FWHM kernel.
+
+.. warning::
+
+   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
 
 Several different individual level analysis are performed on the fMRI data including:
 
 * **Amplitude of low frequency fluctuations (alff) [10]:** the variance of each voxel is calculated after bandpass filtering in original space and subsequently written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel.
 * **Fractional amplitude of low frequency fluctuations (falff) [11]:** Similar to alff except that the variance of the bandpassed signal is divided by the total variance (variance of non-bandpassed signal.
+.. warning::
+
+   :doc:`/user/known-issues/FCP-INDI/C-PAC/2152`
 * **Regional homogeniety (ReHo) [12]:** a simultaneous Kendalls correlation is calculated between each voxel's time course and the time courses of the 27 voxels that are face, edge, and corner touching the voxel. ReHo is calculated in original space and subsequently written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel.
 * **Voxel mirrored homotopic connectivity (VMHC) [13]:** an non-linear transform is calculated between the skull-on anatomical data and a symmetric brain template in 2mm space. Using this transform, processed fMRI data are written in to symmetric MNI space at 2mm and the correlation between each voxel and its analog in the contralateral hemisphere is calculated. The Fisher transform is applied to the resulting values, which are then spatially smoothed using a 6mm FWHM kernel.
 * **Weighted and binarized degree centrality (DC) [14]:** fMRI data is written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel. The voxel x voxel similarity matrix is calculated by the correlation between every pair of voxel time courses and then thresholded so that only the top 5% of correlations remain. For each voxel, binarized DC is the number of connections that remain for the voxel after thresholding and weighted DC is the average correlation coefficient across the remaining connections.


### PR DESCRIPTION
## Documents
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Documents #[issue number]" to "Documents #1". -->
Documents FCP-INDI/C-PAC#2152 by Shinwon Park
Documents FCP-INDI/C-PAC#2153 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->
Adds
* documentation regarding this bug and its resolution to [Troubleshooting and Help § Recently Resolved Common Issues](https://fcp-indi.github.io/docs/nightly/user/help#recently-resolved-common-issues)
* warnings linking to that documentation in places where bandpass filtering is mentioned in the user docs:
  * Nuisance Signal Regression
    * [§ Configuring Nuisance Signal Regression Options: Configuring Temporal Filtering Options](https://fcp-indi.github.io/docs/nightly/user/nuisance#configuring-temporal-filtering-options): 2. Select regressors
    * [§ Pulling Regressors from fMRIPrep Output Directory](https://fcp-indi.github.io/docs/nightly/user/nuisance#pulling-regressors-from-fmriprep-output-directory)
  * [Pre-configured Pipelines § human: default: The Default Pipeline](https://fcp-indi.github.io/docs/nightly/user/pipelines/preconfig#default-the-default-pipeline)
    * After <blockquote>The default processing pipeline performs fMRI processing using four strategies, with and without global signal regression, with and without bandpass filtering.</blockquote>
    * After <blockquote>The residuals of the NVR procedure are processed with and without bandpass filtering (0.01Hz < f < 0.1Hz), written into MNI space at 3mm resolution and subsequently smoothed using a 6mm FWHM kernel.</blockquote>
    * After <blockquote>Amplitude of low frequency fluctuations (alff)<sup>[9]</sup>: the variance of each voxel is calculated after bandpass filtering in original space and subsequently written into MNI space at 2mm resolution and spatially smoothed using a 6mm FWHM kernel.</blockquote>
    * After <blockquote>Fractional amplitude of low frequency fluctuations (falff)<sup>[10]</sup>: Similar to alff except that the variance of the bandpassed signal is divided by the total variance (variance of non-bandpassed signal).</blockquote>
  * [C-PAC Quickstart § Default Pipeline](https://fcp-indi.github.io/docs/nightly/user/quick#default-pipeline)
    * Same places as in *Pre-configured Pipelines § human: default: The Default Pipeline*

<span title="Single Source of Truth">SSOT</span>s default pipeline description (same text, slightly out of sync, was present in *Pre-configured Pipelines § human: default: The Default Pipeline* and *C-PAC Quickstart § Default Pipeline*)

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

### Troubleshooting and Help § Recently Resolved Common Issues

![https://fcp-indi.github.io/docs/nightly/user/help#recently-resolved-common-issues](https://github.com/user-attachments/assets/e1d1e993-2854-4971-a444-aa93fc0491c5)

### Nuisance Signal Regression

![https://fcp-indi.github.io/docs/nightly/user/nuisance#configuring-temporal-filtering-options](https://github.com/user-attachments/assets/3b029d51-8bee-495a-ad6f-652ecb530d20)

![fcp-indi.github.io/docs/nightly/user/nuisance#pulling-regressors-from-fmriprep-output-directory](https://github.com/user-attachments/assets/2f1d0fc2-0f41-4bb4-9a19-d71c45b6e56e)

### Pre-configured Pipelines § human: default: The Default Pipeline

![https://fcp-indi.github.io/docs/nightly/user/pipelines/preconfig#default-the-default-pipeline](https://github.com/user-attachments/assets/b9bb47f1-3d9c-45ab-a74f-1903a61f4861)

![https://fcp-indi.github.io/docs/nightly/user/pipelines/preconfig#default-the-default-pipeline](https://github.com/user-attachments/assets/9c08aedf-54d7-48c8-b5e4-70f65ea9da92)

### C-PAC Quickstart § Default Pipeline


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).  <!-- If you want to in include a leading emoji, check out https://gitmoji.dev for a pseudo-standard set of options -->
- [x] My pull request targets the `source` branch of the repository. <!-- Change this branch if you're targeting a branch other than `source` -->
- [x] My commit messages follow best practices.
- [x] My code follows the [established code style of the repository](../CONTRIBUTING.md).
- [x] I tried [letting the CI build this branch on a fork or built the project locally](../CONTRIBUTING.md#building) and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
